### PR TITLE
Add proper Python3 support to the generator

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -175,7 +175,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.c"
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
-      COMMAND ${PYTHON2_EXECUTABLE}
+      COMMAND ${PYTHON_EXECUTABLE}
       ARGS ${NANOPB_GENERATOR_EXECUTABLE} ${FIL_WE}.pb ${NANOPB_OPTIONS}
       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb"
       COMMENT "Running nanopb generator on ${FIL_WE}.pb"
@@ -244,17 +244,7 @@ find_file(NANOPB_GENERATOR_EXECUTABLE
 )
 mark_as_advanced(NANOPB_GENERATOR_EXECUTABLE)
 
-# If python3 has already been found, save it and look for python2.6
-if(${PYTHON_VERSION_MAJOR} AND ${PYTHON_VERSION_MAJOR} EQUAL 3)
-    set(PYTHON3_EXECUTABLE ${PYTHON_EXECUTABLE})
-    set(PYTHON_EXECUTABLE PYTHON_EXECUTABLE-NOTFOUND)
-    find_package(PythonInterp 2.6 REQUIRED)
-    set(PYTHON2_EXECUTABLE ${PYTHON_EXECUTABLE})
-    set(PYTHON_EXECUTABLE ${PYTHON3_EXECUTABLE})
-else()
-    find_package(PythonInterp 2.6 REQUIRED)
-    set(PYTHON2_EXECUTABLE ${PYTHON_EXECUTABLE})
-endif()
+find_package(PythonInterp REQUIRED)
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(NANOPB DEFAULT_MSG

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import unicode_literals
 

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -379,12 +379,10 @@ class Field:
                 inner_init = '0'
         else:
             if self.pbtype == 'STRING':
-                inner_init = self.default.encode('utf-8').encode('string_escape')
-                inner_init = inner_init.replace('"', '\\"')
+                inner_init = self.default.replace('"', '\\"')
                 inner_init = '"' + inner_init + '"'
             elif self.pbtype == 'BYTES':
-                data = str(self.default).decode('string_escape')
-                data = ['0x%02x' % ord(c) for c in data]
+                data = ['0x%02x' % ord(c) for c in self.default]
                 if len(data) == 0:
                     inner_init = '{0, {0}}'
                 else:

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -85,7 +85,14 @@ class Names:
         return '_'.join(self.parts)
 
     def __add__(self, other):
-        if isinstance(other, str):
+        # The fdesc names are unicode and need to be handled for
+        # python2 and python3
+        try:
+              realstr = unicode
+        except NameError:
+              realstr = str
+
+        if isinstance(other, realstr):
             return Names(self.parts + (other,))
         elif isinstance(other, tuple):
             return Names(self.parts + other)

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -314,8 +314,8 @@ class Field:
         else:
             raise NotImplementedError(desc.type)
         
-    def __cmp__(self, other):
-        return cmp(self.tag, other.tag)
+    def __lt__(self, other):
+        return self.tag < other.tag
     
     def __str__(self):
         result = ''
@@ -660,9 +660,6 @@ class OneOf(Field):
 
         # Sort by the lowest tag number inside union
         self.tag = min([f.tag for f in self.fields])
-
-    def __cmp__(self, other):
-        return cmp(self.tag, other.tag)
 
     def __str__(self):
         result = ''

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1440,14 +1440,15 @@ def main_cli():
 def main_plugin():
     '''Main function when invoked as a protoc plugin.'''
 
-    import sys
+    import io, sys
     if sys.platform == "win32":
         import os, msvcrt
         # Set stdin and stdout to binary mode
         msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
         msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
     
-    data = sys.stdin.read()
+    data = io.open(sys.stdin.fileno(), "rb").read()
+
     request = plugin_pb2.CodeGeneratorRequest.FromString(data)
     
     try:
@@ -1490,7 +1491,7 @@ def main_plugin():
                 f.name = results['sourcename']
                 f.content = results['sourcedata']    
     
-    sys.stdout.write(response.SerializeToString())
+    io.open(sys.stdout.fileno(), "wb").write(response.SerializeToString())
 
 if __name__ == '__main__':
     # Check if we are running as a plugin under protoc

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import unicode_literals
+
 '''Generate header file for nanopb from a ProtoBuf FileDescriptorSet.'''
 nanopb_version = "nanopb-0.3.4-dev"
 

--- a/generator/protoc-gen-nanopb
+++ b/generator/protoc-gen-nanopb
@@ -10,5 +10,4 @@
 # --plugin= on the command line.
 
 MYPATH=$(dirname "$0")
-PYTHON=$(which python2 || which python)
-exec $PYTHON "$MYPATH/nanopb_generator.py" --protoc-plugin
+exec "$MYPATH/nanopb_generator.py" --protoc-plugin


### PR DESCRIPTION
This pull request attempts to port `nanopb_generator.py` to a python2 *and* python3 compatible version.

Arch Linux already defaults to python3 and Ubuntu and Debian are forthcoming.  My Arch Linux install had a python-protobuf build for python3, but not for python2.  As a result, none of the hacks to force python2 worked.

I've tested this against the unit tests and it seems good for both python2 and python3.

Test systems for python3: Arch Linux up to date as of today

* clang 3.6.2-4
* cmake 3.3.2-2
* protobuf 2.6.1-1
* python 3.4.3-3
* python-protobuf 3.0.0a3-2
* scons 2.3.6-1

Python 2 testing was in a docker container running Ubuntu:14.04:

* cmake  2.8.12.2-0ubuntu3
* gcc 4:4.8.2-1ubuntu6
* protobuf 2.6.1 (built from source as 2.5.x in apt has issues with oneof it appears)
* python 2.7.5-5ubuntu3
* python-protobuf 2.6.1 (built and installed via pip)
* scons 2.3.0-2

All of the ASCII string vs unicode stuff is a complete headache and I'm not convinced it's 100% correct in python2, but all unit tests at least pass.