### PR TITLE
Add Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,49 @@
-language: c
+# Travis CI has no ability to handle 3 langauges (c, c++, python)
+# and it overrides $CC/$CXX if language is set to c/c++ (only one, not both).
+#
+# Set language to python since at least the result of that is something useful.
+language: python
 
-compiler:
-    - gcc
-    - clang
+python:
+    - "2.7"
+    - "3.4"
+
+# Manage the C/C++ compiler manually
+env:
+    - CC=gcc     CXX=g++
+    - CC=gcc-4.8 CXX=g++-4.8
+    - CC=gcc-4.9 CXX=g++-4.9
+    - CC=gcc-5   CXX=g++-5
+    - CC=clang   CXX=clang++
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-4.8
+            - g++-4.8
+            - gcc-4.9
+            - g++-4.9
+            - gcc-5
+            - g++-5
+
 
 before_install:
     - export PATH=$HOME/.local/bin:$HOME/protobuf/bin:$PATH
     - export MAKEFLAGS=-j$(grep processor /proc/cpuinfo | wc -l)
     - $CC --version
+    - $CXX --version
     - python --version
     - lsb_release -a
 
-cache:
-    directories:
-        - $HOME/protobuf
+# Seems to be issues with concurrent builds
+#cache:
+#    directories:
+#        - $HOME/protobuf
+
 install:
-    - pip install --user protobuf
+    - pip install protobuf
     - test \! -d $HOME/protobuf
       && curl -L https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2 | tar xjf -
       && pushd protobuf-2.6.1
@@ -23,6 +51,6 @@ install:
       && popd
       || true # True if test is false as the cache exists
 
-script: 
+script:
     - pushd generator/proto && make && popd
-    - pushd tests && scons && popd
+    - pushd tests && python2 $(which scons) CC=$CC CXX=$CXX && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+
+compiler:
+    - gcc
+    - clang
+
+before_install:
+    - export PATH=$HOME/.local/bin:$HOME/protobuf/bin:$PATH
+    - export MAKEFLAGS=-j$(grep processor /proc/cpuinfo | wc -l)
+    - $CC --version
+    - python --version
+    - lsb_release -a
+
+cache:
+    directories:
+        - $HOME/protobuf
+install:
+    - pip install --user protobuf
+    - test \! -d $HOME/protobuf
+      && curl -L https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2 | tar xjf -
+      && pushd protobuf-2.6.1
+      && ./configure --prefix=$HOME/protobuf && make && make install
+      && popd
+      || true # True if test is false as the cache exists
+
+script: 
+    - pushd generator/proto && make && popd
+    - pushd tests && scons && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,11 @@ before_install:
 #        - $HOME/protobuf
 
 install:
-    - pip install protobuf
-    - test \! -d $HOME/protobuf
-      && curl -L https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2 | tar xjf -
-      && pushd protobuf-2.6.1
+    - curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-1/protobuf-python-3.0.0-alpha-4.tar.gz | tar xzf -
+      && pushd protobuf-3.0.0-alpha-4
       && ./configure --prefix=$HOME/protobuf && make && make install
+      && pushd python && python setup.py build && python setup.py install && popd
       && popd
-      || true # True if test is false as the cache exists
 
 script:
     - pushd generator/proto && make && popd


### PR DESCRIPTION
Travis CI will provide a simple automated mechanism to run the unit tests to make sure every pull requests works as expected on a matrix of compilers and python releases.

This is my first stab at making it work.  My repo's builds are @ https://travis-ci.org/kylemanna/nanopb

A Travis CI account will need to be setup for the main nanopb repository.

Related to #169