### PR TITLE
decode: Fix compiler issue with gcc-5

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -886,7 +886,8 @@ bool checkreturn pb_decode_noinit(pb_istream_t *stream, const pb_field_t fields[
         if (PB_HTYPE(iter.pos->type) == PB_HTYPE_REQUIRED
             && iter.required_field_index < PB_MAX_REQUIRED_FIELDS)
         {
-            fields_seen[iter.required_field_index >> 3] |= (uint8_t)(1 << (iter.required_field_index & 7));
+            uint8_t tmp = (uint8_t)(1 << (iter.required_field_index & 7));
+            fields_seen[iter.required_field_index >> 3] |= tmp;
         }
             
         if (!decode_field(stream, wire_type, &iter))


### PR DESCRIPTION
* gcc 5.0 and 5.1 appear to take issue with this line and generates the
  following error:

    /home/nitro/tmp/nanopb/pb_decode.c: In function ‘pb_decode_noinit’:
    /home/nitro/tmp/nanopb/pb_decode.c:889:60: error: conversion to ‘uint8_t {aka unsigned char}’ from ‘int’ may alter its value [-Werror=conversion]
                 fields_seen[iter.required_field_index >> 3] |= (uint8_t)(1 << (iter.required_field_index & 7));
                                                                ^
* This seems like a compiler bug, but this workaround is harmless.