### PR TITLE
Cmake

### DIFF
--- a/examples/cmake_simple/CMakeLists.txt
+++ b/examples/cmake_simple/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(NANOPB_CMAKE_SIMPLE C)
 
-set(NANOPB_SRC_ROOT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/../..)
-set(CMAKE_MODULE_PATH ${NANOPB_SRC_ROOT_FOLDER}/extra)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)
 find_package(Nanopb REQUIRED)
 include_directories(${NANOPB_INCLUDE_DIRS})
 

--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -1,10 +1,6 @@
 # This is an example script for use with CMake projects for locating and configuring
 # the nanopb library.
 #
-# The following varialbes have to be set:
-#
-#   NANOPB_SRC_ROOT_FOLDER  - Path to nanopb source folder
-#
 # The following variables can be set and are optional:
 #
 #
@@ -215,6 +211,12 @@ endfunction()
 # for each directory where a proto file is referenced.
 if(NOT DEFINED NANOPB_GENERATE_CPP_APPEND_PATH)
   set(NANOPB_GENERATE_CPP_APPEND_PATH TRUE)
+endif()
+
+# Make a really good guess regarding location of NANOPB_SRC_ROOT_FOLDER
+if(NOT DEFINED NANOPB_SRC_ROOT_FOLDER)
+  get_filename_component(NANOPB_SRC_ROOT_FOLDER
+                         ${CMAKE_CURRENT_LIST_DIR}/.. ABSOLUTE)
 endif()
 
 # Find the include directory


### PR DESCRIPTION
* Enhancements that affect cmake only
* Build the protobuf generator files out of tree in the build directory
* Don't require `NANOPB_SRC_ROOT_FOLDER`