### PR TITLE
Add option to allow for anonymous unions

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -653,6 +653,7 @@ class OneOf(Field):
         self.allocation = 'ONEOF'
         self.default = None
         self.rules = 'ONEOF'
+        self.anonymous = False
 
     def add_field(self, field):
         if field.allocation == 'CALLBACK':
@@ -674,7 +675,10 @@ class OneOf(Field):
             result += '    union {\n'
             for f in self.fields:
                 result += '    ' + str(f).replace('\n', '\n    ') + '\n'
-            result += '    } ' + self.name + ';'
+            if self.anonymous:
+                result += '    };'
+            else:
+                result += '    } ' + self.name + ';'
         return result
 
     def types(self):
@@ -742,6 +746,8 @@ class Message:
                     pass # No union and skip fields also
                 else:
                     oneof = OneOf(self.name, f)
+                    if oneof_options.anonymous:
+                        oneof.anonymous = True
                     self.oneofs[i] = oneof
                     self.fields.append(oneof)
 

--- a/generator/proto/nanopb.proto
+++ b/generator/proto/nanopb.proto
@@ -62,6 +62,9 @@ message NanoPBOptions {
 
   // integer type tag for a message
   optional uint32 msgid = 9;
+
+  // declare union or sub-message as an anonymous union/struct
+  optional bool anonymous = 11 [default = false];
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options


### PR DESCRIPTION
gnu99 and c11 both support anonymous unions, and being able to generate them could improve code quality in some cases.