### PR TITLE
Add option to allow for anonymous unions

### DIFF
--- a/generator/proto/nanopb.proto
+++ b/generator/proto/nanopb.proto
@@ -62,6 +62,9 @@ message NanoPBOptions {
 
   // integer type tag for a message
   optional uint32 msgid = 9;
+
+  // decode oneof as anonymous union
+  optional bool anonymous_oneof = 11 [default = false];
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options

--- a/pb.h
+++ b/pb.h
@@ -518,8 +518,23 @@ struct pb_extension_s {
     pb_membersize(st, u.m[0]), 0, ptr}
 
 #define PB_ONEOF_FIELD(union_name, tag, type, rules, allocation, placement, message, field, prevfield, ptr) \
-        PB_ ## rules ## _ ## allocation(union_name, tag, message, field, \
+        PB_ ## ONEOF_ ## allocation(union_name, tag, message, field, \
         PB_DATAOFFSET_ ## placement(message, union_name.field, prevfield), \
+        PB_LTYPE_MAP_ ## type, ptr)
+
+#define PB_ANONYMOUS_ONEOF_STATIC(u, tag, st, m, fd, ltype, ptr) \
+    {tag, PB_ATYPE_STATIC | PB_HTYPE_ONEOF | ltype, \
+    fd, pb_delta(st, which_ ## u, m), \
+    pb_membersize(st, m), 0, ptr}
+
+#define PB_ANONYMOUS_ONEOF_POINTER(u, tag, st, m, fd, ltype, ptr) \
+    {tag, PB_ATYPE_POINTER | PB_HTYPE_ONEOF | ltype, \
+    fd, pb_delta(st, which_ ## u, m), \
+    pb_membersize(st, m[0]), 0, ptr}
+
+#define PB_ANONYMOUS_ONEOF_FIELD(union_name, tag, type, rules, allocation, placement, message, field, prevfield, ptr) \
+        PB_ ## ANONYMOUS_ONEOF_ ## allocation(union_name, tag, message, field, \
+        PB_DATAOFFSET_ ## placement(message, field, prevfield), \
         PB_LTYPE_MAP_ ## type, ptr)
 
 /* These macros are used for giving out error messages.


### PR DESCRIPTION
I have another implementation where I overload the 'anonymous' flag inside of the field rules as 'ONEOF' or 'ANONYMOUS_ONEOF'. I feel like I am relatively unfamiliar with a lot of the generator functionality so I would love feedback if you can think of a better way to do this, or at least one that is more consistent with the project style.