### PR TITLE
Fix incorrect operation on TI's DSC

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -41,6 +41,10 @@
  * This was the default until nanopb-0.2.1. */
 /* #define PB_OLD_CALLBACK_STYLE */
 
+/* Switch this on if target platform provide unusual integer sizes.
+ * This takes places on platforms with minimal addreassable space bigger than
+ * one byte. Some TI's MCU or DSP for an example. */
+/* #define PB_UNUSUAL_INT_SIZE */
 
 /******************************************************************
  * You usually don't need to change anything below this line.     *
@@ -55,7 +59,7 @@
 /* Include all the system headers needed by nanopb. You will need the
  * definitions of the following:
  * - strlen, memcpy, memset functions
- * - [u]int8_t, [u]int16_t, [u]int32_t, [u]int64_t
+ * - [u]int_least8_t, [u]int_least16_t, [u]int32_t, [u]int64_t
  * - size_t
  * - bool
  *
@@ -144,7 +148,7 @@
  * Most-significant 4 bits specify repeated/required/packed etc.
  */
 
-typedef uint8_t pb_type_t;
+typedef uint_least8_t pb_type_t;
 
 /**** Field data types ****/
 
@@ -205,13 +209,13 @@ typedef uint8_t pb_type_t;
     typedef uint32_t pb_size_t;
     typedef int32_t pb_ssize_t;
 #elif defined(PB_FIELD_16BIT)
-#define PB_SIZE_MAX ((uint16_t)-1)
-    typedef uint16_t pb_size_t;
-    typedef int16_t pb_ssize_t;
+#define PB_SIZE_MAX ((uint_least16_t)-1)
+    typedef uint_least16_t pb_size_t;
+    typedef int_least16_t pb_ssize_t;
 #else
-#define PB_SIZE_MAX ((uint8_t)-1)
-    typedef uint8_t pb_size_t;
-    typedef int8_t pb_ssize_t;
+#define PB_SIZE_MAX ((uint_least8_t)-1)
+    typedef uint_least8_t pb_size_t;
+    typedef int_least8_t pb_ssize_t;
 #endif
 
 /* This structure is used in auto-generated constants
@@ -245,25 +249,28 @@ PB_PACKED_STRUCT_END
  * If you get errors here, it probably means that your stdint.h is not
  * correct for your platform.
  */
-PB_STATIC_ASSERT(sizeof(int8_t) == 1, INT8_T_WRONG_SIZE)
-PB_STATIC_ASSERT(sizeof(uint8_t) == 1, UINT8_T_WRONG_SIZE)
-PB_STATIC_ASSERT(sizeof(int16_t) == 2, INT16_T_WRONG_SIZE)
-PB_STATIC_ASSERT(sizeof(uint16_t) == 2, UINT16_T_WRONG_SIZE)
+
+#ifndef PB_UNUSUAL_INT_SIZE
+PB_STATIC_ASSERT(sizeof(int_least8_t) == 1, INT8_T_WRONG_SIZE)
+PB_STATIC_ASSERT(sizeof(uint_least8_t) == 1, UINT8_T_WRONG_SIZE)
+PB_STATIC_ASSERT(sizeof(int_least16_t) == 2, INT16_T_WRONG_SIZE)
+PB_STATIC_ASSERT(sizeof(uint_least16_t) == 2, UINT16_T_WRONG_SIZE)
 PB_STATIC_ASSERT(sizeof(int32_t) == 4, INT32_T_WRONG_SIZE)
 PB_STATIC_ASSERT(sizeof(uint32_t) == 4, UINT32_T_WRONG_SIZE)
 PB_STATIC_ASSERT(sizeof(int64_t) == 8, INT64_T_WRONG_SIZE)
 PB_STATIC_ASSERT(sizeof(uint64_t) == 8, UINT64_T_WRONG_SIZE)
+#endif
 
 /* This structure is used for 'bytes' arrays.
  * It has the number of bytes in the beginning, and after that an array.
  * Note that actual structs used will have a different length of bytes array.
  */
-#define PB_BYTES_ARRAY_T(n) struct { pb_size_t size; uint8_t bytes[n]; }
+#define PB_BYTES_ARRAY_T(n) struct { pb_size_t size; uint_least8_t bytes[n]; }
 #define PB_BYTES_ARRAY_T_ALLOCSIZE(n) ((size_t)n + offsetof(pb_bytes_array_t, bytes))
 
 struct pb_bytes_array_s {
     pb_size_t size;
-    uint8_t bytes[1];
+    uint_least8_t bytes[1];
 };
 typedef struct pb_bytes_array_s pb_bytes_array_t;
 

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -23,9 +23,9 @@
 
 typedef bool (*pb_decoder_t)(pb_istream_t *stream, const pb_field_t *field, void *dest) checkreturn;
 
-static bool checkreturn buf_read(pb_istream_t *stream, uint8_t *buf, size_t count);
+static bool checkreturn buf_read(pb_istream_t *stream, uint_least8_t *buf, size_t count);
 static bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest);
-static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire_type, uint8_t *buf, size_t *size);
+static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire_type, uint_least8_t *buf, size_t *size);
 static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *iter);
 static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *iter);
 static bool checkreturn decode_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *iter);
@@ -72,10 +72,10 @@ static const pb_decoder_t PB_DECODERS[PB_LTYPES_COUNT] = {
  * pb_istream_t implementation *
  *******************************/
 
-static bool checkreturn buf_read(pb_istream_t *stream, uint8_t *buf, size_t count)
+static bool checkreturn buf_read(pb_istream_t *stream, uint_least8_t *buf, size_t count)
 {
-    const uint8_t *source = (const uint8_t*)stream->state;
-    stream->state = (uint8_t*)stream->state + count;
+    const uint_least8_t *source = (const uint_least8_t*)stream->state;
+    stream->state = (uint_least8_t*)stream->state + count;
     
     if (buf != NULL)
     {
@@ -86,13 +86,13 @@ static bool checkreturn buf_read(pb_istream_t *stream, uint8_t *buf, size_t coun
     return true;
 }
 
-bool checkreturn pb_read(pb_istream_t *stream, uint8_t *buf, size_t count)
+bool checkreturn pb_read(pb_istream_t *stream, uint_least8_t *buf, size_t count)
 {
 #ifndef PB_BUFFER_ONLY
 	if (buf == NULL && stream->callback != buf_read)
 	{
 		/* Skip input bytes */
-		uint8_t tmp[16];
+		uint_least8_t tmp[16];
 		while (count > 16)
 		{
 			if (!pb_read(stream, tmp, 16))
@@ -122,7 +122,7 @@ bool checkreturn pb_read(pb_istream_t *stream, uint8_t *buf, size_t count)
 
 /* Read a single byte from input stream. buf may not be NULL.
  * This is an optimization for the varint decoding. */
-static bool checkreturn pb_readbyte(pb_istream_t *stream, uint8_t *buf)
+static bool checkreturn pb_readbyte(pb_istream_t *stream, uint_least8_t *buf)
 {
     if (stream->bytes_left == 0)
         PB_RETURN_ERROR(stream, "end-of-stream");
@@ -131,8 +131,8 @@ static bool checkreturn pb_readbyte(pb_istream_t *stream, uint8_t *buf)
     if (!stream->callback(stream, buf, 1))
         PB_RETURN_ERROR(stream, "io error");
 #else
-    *buf = *(const uint8_t*)stream->state;
-    stream->state = (uint8_t*)stream->state + 1;
+    *buf = *(const uint_least8_t*)stream->state;
+    stream->state = (uint_least8_t*)stream->state + 1;
 #endif
 
     stream->bytes_left--;
@@ -140,7 +140,7 @@ static bool checkreturn pb_readbyte(pb_istream_t *stream, uint8_t *buf)
     return true;    
 }
 
-pb_istream_t pb_istream_from_buffer(const uint8_t *buf, size_t bufsize)
+pb_istream_t pb_istream_from_buffer(const uint_least8_t *buf, size_t bufsize)
 {
     pb_istream_t stream;
     /* Cast away the const from buf without a compiler error.  We are
@@ -170,7 +170,7 @@ pb_istream_t pb_istream_from_buffer(const uint8_t *buf, size_t bufsize)
 
 static bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
 {
-    uint8_t byte;
+    uint_least8_t byte;
     uint32_t result;
     
     if (!pb_readbyte(stream, &byte))
@@ -184,7 +184,7 @@ static bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
     else
     {
         /* Multibyte case */
-        uint8_t bitpos = 7;
+        uint_least8_t bitpos = 7;
         result = byte & 0x7F;
         
         do
@@ -196,7 +196,7 @@ static bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
                 return false;
             
             result |= (uint32_t)(byte & 0x7F) << bitpos;
-            bitpos = (uint8_t)(bitpos + 7);
+            bitpos = (uint_least8_t)(bitpos + 7);
         } while (byte & 0x80);
    }
    
@@ -206,8 +206,8 @@ static bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
 
 bool checkreturn pb_decode_varint(pb_istream_t *stream, uint64_t *dest)
 {
-    uint8_t byte;
-    uint8_t bitpos = 0;
+    uint_least8_t byte;
+    uint_least8_t bitpos = 0;
     uint64_t result = 0;
     
     do
@@ -219,7 +219,7 @@ bool checkreturn pb_decode_varint(pb_istream_t *stream, uint64_t *dest)
             return false;
 
         result |= (uint64_t)(byte & 0x7F) << bitpos;
-        bitpos = (uint8_t)(bitpos + 7);
+        bitpos = (uint_least8_t)(bitpos + 7);
     } while (byte & 0x80);
     
     *dest = result;
@@ -228,7 +228,7 @@ bool checkreturn pb_decode_varint(pb_istream_t *stream, uint64_t *dest)
 
 bool checkreturn pb_skip_varint(pb_istream_t *stream)
 {
-    uint8_t byte;
+    uint_least8_t byte;
     do
     {
         if (!pb_read(stream, &byte, 1))
@@ -287,7 +287,7 @@ bool checkreturn pb_skip_field(pb_istream_t *stream, pb_wire_type_t wire_type)
 /* Read a raw value to buffer, for the purpose of passing it to callback as
  * a substream. Size is maximum size on call, and actual size on return.
  */
-static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire_type, uint8_t *buf, size_t *size)
+static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire_type, uint_least8_t *buf, size_t *size)
 {
     size_t max_size = *size;
     switch (wire_type)
@@ -375,7 +375,7 @@ static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t
                 
                 while (substream.bytes_left > 0 && *size < iter->pos->array_size)
                 {
-                    void *pItem = (uint8_t*)iter->pData + iter->pos->data_size * (*size);
+                    void *pItem = (uint_least8_t*)iter->pData + iter->pos->data_size * (*size);
                     if (!func(&substream, iter->pos, pItem))
                     {
                         status = false;
@@ -394,7 +394,7 @@ static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t
             {
                 /* Repeated field */
                 pb_size_t *size = (pb_size_t*)iter->pSize;
-                void *pItem = (uint8_t*)iter->pData + iter->pos->data_size * (*size);
+                void *pItem = (uint_least8_t*)iter->pData + iter->pos->data_size * (*size);
                 if (*size >= iter->pos->array_size)
                     PB_RETURN_ERROR(stream, "array overflow");
                 
@@ -548,7 +548,7 @@ static bool checkreturn decode_pointer_field(pb_istream_t *stream, pb_wire_type_
                     }
 
                     /* Decode the array entry */
-                    pItem = *(uint8_t**)iter->pData + iter->pos->data_size * (*size);
+                    pItem = *(uint_least8_t**)iter->pData + iter->pos->data_size * (*size);
                     initialize_pointer_field(pItem, iter);
                     if (!func(&substream, iter->pos, pItem))
                     {
@@ -584,7 +584,7 @@ static bool checkreturn decode_pointer_field(pb_istream_t *stream, pb_wire_type_
                 if (!allocate_field(stream, iter->pData, iter->pos->data_size, *size))
                     return false;
             
-                pItem = *(uint8_t**)iter->pData + iter->pos->data_size * (*size - 1);
+                pItem = *(uint_least8_t**)iter->pData + iter->pos->data_size * (*size - 1);
                 initialize_pointer_field(pItem, iter);
                 return func(stream, iter->pos, pItem);
             }
@@ -631,7 +631,7 @@ static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type
          * which in turn allows to use same callback for packed and
          * not-packed fields. */
         pb_istream_t substream;
-        uint8_t buffer[10];
+        uint_least8_t buffer[10];
         size_t size = sizeof(buffer);
         
         if (!read_raw_value(stream, wire_type, buffer, &size))
@@ -838,7 +838,7 @@ static void pb_message_set_to_defaults(const pb_field_t fields[], void *dest_str
 
 bool checkreturn pb_decode_noinit(pb_istream_t *stream, const pb_field_t fields[], void *dest_struct)
 {
-    uint8_t fields_seen[(PB_MAX_REQUIRED_FIELDS + 7) / 8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint_least8_t fields_seen[(PB_MAX_REQUIRED_FIELDS + 7) / 8] = {0, 0, 0, 0, 0, 0, 0, 0};
     uint32_t extension_range_start = 0;
     pb_field_iter_t iter;
     
@@ -894,7 +894,7 @@ bool checkreturn pb_decode_noinit(pb_istream_t *stream, const pb_field_t fields[
         if (PB_HTYPE(iter.pos->type) == PB_HTYPE_REQUIRED
             && iter.required_field_index < PB_MAX_REQUIRED_FIELDS)
         {
-            uint8_t tmp = (uint8_t)(1 << (iter.required_field_index & 7));
+            uint_least8_t tmp = (uint_least8_t)(1 << (iter.required_field_index & 7));
             fields_seen[iter.required_field_index >> 3] |= tmp;
         }
             
@@ -1038,7 +1038,7 @@ static void pb_release_single_field(const pb_field_iter_t *iter)
             while (count--)
             {
                 pb_release((const pb_field_t*)iter->pos->ptr, pItem);
-                pItem = (uint8_t*)pItem + iter->pos->data_size;
+                pItem = (uint_least8_t*)pItem + iter->pos->data_size;
             }
         }
     }
@@ -1106,44 +1106,49 @@ bool pb_decode_svarint(pb_istream_t *stream, int64_t *dest)
 
 bool pb_decode_fixed32(pb_istream_t *stream, void *dest)
 {
-    #ifdef __BIG_ENDIAN__
-    uint8_t *bytes = (uint8_t*)dest;
-    uint8_t lebytes[4];
+    uint_least8_t bytes[4];
     
-    if (!pb_read(stream, lebytes, 4))
+    if (!pb_read(stream, bytes, 4))
         return false;
     
-    bytes[0] = lebytes[3];
-    bytes[1] = lebytes[2];
-    bytes[2] = lebytes[1];
-    bytes[3] = lebytes[0];
-    return true;
+    #ifdef __BIG_ENDIAN__
+    *(uint32_t*)dest =   bytes[3] | ((uint32_t)bytes[2] << 8) |
+                        ((uint32_t)bytes[1] << 16) |
+                        ((uint32_t)bytes[0] << 24);
     #else
-    return pb_read(stream, (uint8_t*)dest, 4);
-    #endif   
+    *(uint32_t*)dest =   bytes[0] | ((uint32_t)bytes[1] << 8) |
+                        ((uint32_t)bytes[2] << 16) |
+                        ((uint32_t)bytes[3] << 24);
+
+    #endif
+    return true;
 }
 
 bool pb_decode_fixed64(pb_istream_t *stream, void *dest)
 {
-    #ifdef __BIG_ENDIAN__
-    uint8_t *bytes = (uint8_t*)dest;
-    uint8_t lebytes[8];
+    uint_least8_t bytes[8];
     
-    if (!pb_read(stream, lebytes, 8))
+    if (!pb_read(stream, bytes, 8))
         return false;
     
-    bytes[0] = lebytes[7];
-    bytes[1] = lebytes[6];
-    bytes[2] = lebytes[5];
-    bytes[3] = lebytes[4];
-    bytes[4] = lebytes[3];
-    bytes[5] = lebytes[2];
-    bytes[6] = lebytes[1];
-    bytes[7] = lebytes[0];
-    return true;
+    #ifdef __BIG_ENDIAN__
+    *(uint64_t*)dest = bytes[7] | ((uint64_t)bytes[6] << 8) |
+                        ((uint64_t)bytes[5] << 16) |
+                        ((uint64_t)bytes[4] << 24) |
+                        ((uint64_t)bytes[3] << 32) |
+                        ((uint64_t)bytes[2] << 40) |
+                        ((uint64_t)bytes[1] << 48) |
+                        ((uint64_t)bytes[0] << 56);
     #else
-    return pb_read(stream, (uint8_t*)dest, 8);
-    #endif   
+    *(uint64_t*)dest = bytes[0] | ((uint64_t)bytes[1] << 8) |
+                        ((uint64_t)bytes[2] << 16) |
+                        ((uint64_t)bytes[3] << 24) |
+                        ((uint64_t)bytes[4] << 32) |
+                        ((uint64_t)bytes[5] << 40) |
+                        ((uint64_t)bytes[6] << 48) |
+                        ((uint64_t)bytes[7] << 56);
+    #endif
+    return true;
 }
 
 static bool checkreturn pb_dec_varint(pb_istream_t *stream, const pb_field_t *field, void *dest)
@@ -1167,8 +1172,8 @@ static bool checkreturn pb_dec_varint(pb_istream_t *stream, const pb_field_t *fi
 
     switch (field->data_size)
     {
-        case 1: clamped = *(int8_t*)dest = (int8_t)svalue; break;
-        case 2: clamped = *(int16_t*)dest = (int16_t)svalue; break;
+        case 1: clamped = *(int_least8_t*)dest = (int_least8_t)svalue; break;
+        case 2: clamped = *(int_least16_t*)dest = (int_least16_t)svalue; break;
         case 4: clamped = *(int32_t*)dest = (int32_t)svalue; break;
         case 8: clamped = *(int64_t*)dest = svalue; break;
         default: PB_RETURN_ERROR(stream, "invalid data_size");
@@ -1188,8 +1193,8 @@ static bool checkreturn pb_dec_uvarint(pb_istream_t *stream, const pb_field_t *f
     
     switch (field->data_size)
     {
-        case 1: clamped = *(uint8_t*)dest = (uint8_t)value; break;
-        case 2: clamped = *(uint16_t*)dest = (uint16_t)value; break;
+        case 1: clamped = *(uint_least8_t*)dest = (uint_least8_t)value; break;
+        case 2: clamped = *(uint_least16_t*)dest = (uint_least16_t)value; break;
         case 4: clamped = *(uint32_t*)dest = (uint32_t)value; break;
         case 8: clamped = *(uint64_t*)dest = value; break;
         default: PB_RETURN_ERROR(stream, "invalid data_size");
@@ -1209,8 +1214,8 @@ static bool checkreturn pb_dec_svarint(pb_istream_t *stream, const pb_field_t *f
     
     switch (field->data_size)
     {
-        case 1: clamped = *(int8_t*)dest = (int8_t)value; break;
-        case 2: clamped = *(int16_t*)dest = (int16_t)value; break;
+        case 1: clamped = *(int_least8_t*)dest = (int_least8_t)value; break;
+        case 2: clamped = *(int_least16_t*)dest = (int_least16_t)value; break;
         case 4: clamped = *(int32_t*)dest = (int32_t)value; break;
         case 8: clamped = *(int64_t*)dest = value; break;
         default: PB_RETURN_ERROR(stream, "invalid data_size");
@@ -1301,8 +1306,8 @@ static bool checkreturn pb_dec_string(pb_istream_t *stream, const pb_field_t *fi
             PB_RETURN_ERROR(stream, "string overflow");
     }
     
-    status = pb_read(stream, (uint8_t*)dest, size);
-    *((uint8_t*)dest + size) = 0;
+    status = pb_read(stream, (uint_least8_t*)dest, size);
+    *((uint_least8_t*)dest + size) = 0;
     return status;
 }
 


### PR DESCRIPTION
Some exotic platforms like [TI 28x](http://www.ti.com/lsds/ti/microcontrollers_16-bit_32-bit/c2000_performance/real-time_control/f2833x_f2837x/overview.page) aligns memory access to even addresses. This means that sizeof(char) equals sizeof(short) equals 1. This kind of platforms are not so rare as one may think.

This commit makes nanopb able to operate properly on such kind of platforms.

Here is brief description of changes:

**[u]int8_t** type lacks in stdint.h so I've changed it to **[u]int_least8_t**.

Also I've removed few dangerous address calculations like [that](https://github.com/baranovmv/nanopb/commit/8f7546b64c52d6bd48ce55dfa58dfece4371a600#diff-42b51cbb4326cbfca72e0b852032247fL447):
```
/* Here are access to different bytes from one integer value */
const uint8_t *bytes = value;
uint8_t lebytes[4];
lebytes[0] = bytes[3];
lebytes[1] = bytes[2];
lebytes[2] = bytes[1];
lebytes[3] = bytes[0];
return pb_write(stream, lebytes, 4);
```
and changed it to this:
```
const uint32_t *words = (const uint32_t*)value;
uint_least8_t bytes[4];
bytes[0] = (uint_least8_t)(*words >> 24) & 0xFF;
bytes[1] = (uint_least8_t)(*words >> 16) & 0xFF;
bytes[2] = (uint_least8_t)(*words >> 8) & 0xFF;
bytes[3] = (uint_least8_t)(*words) & 0xFF;
return pb_write(stream, bytes, 4);
```

This commit works on TMS320F28335 and intel x86 platforms.