### PR TITLE
Generate MIN/MAX/ARRAYSIZE for enums

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -197,6 +197,10 @@ class Enum:
 
         result += ' %s;' % self.names
 
+        result += '\n#define _%s_MIN %s' % (self.names, self.values[0][0])
+        result += '\n#define _%s_MAX %s' % (self.names, self.values[-1][0])
+        result += '\n#define _%s_ARRAYSIZE ((%s)(%s+1))' % (self.names, self.names, self.values[-1][0])
+
         if not self.options.long_names:
             # Define the long names always so that enum value references
             # from other files work properly.


### PR DESCRIPTION
This generates #defines mirroring the following values from the generated C++ code of GPB
* const Foo Foo_MIN: the smallest valid value of the enum (VALUE_A in the example).
* const Foo Foo_MAX: the largest valid value of the enum (VALUE_C in the example).
* const Foo Foo_ARRAYSIZE: always defined as Foo_MAX + 1.

The naming convention (e.g., `_MyEnum_MIN`) has been chosen to avoid conflicts with possible declared values.  `MyEnum__MIN` would be another obvious possibility.