### PR TITLE
Converting CamelCase to C style, adding _t for enums and messages

### DIFF
--- a/generator/camel_case_splitter.py
+++ b/generator/camel_case_splitter.py
@@ -1,0 +1,40 @@
+def split_camel_case(input):
+    def remove_camel_case(camel_case_input):
+        no_camel_case = ""
+        if len(camel_case_input) <= 0:
+            return ""
+        no_camel_case += camel_case_input[0].lower()
+        for c in camel_case_input[1:]:
+            if c.isupper():
+                no_camel_case += "_" + c.lower()
+            else:
+                no_camel_case += c
+        return no_camel_case
+
+    underscore_split = input.split("_")
+    retval = ""
+    should_be_upper = False
+    for i in underscore_split:
+        if i.isupper():
+            should_be_upper = True
+        if is_camel_case_name(i):
+            retval += remove_camel_case(i) + "_"
+        else:
+            retval += i + "_"
+
+    if should_be_upper:
+        retval = retval.upper()
+    return retval[:-1].replace("__", "_")
+
+
+def is_camel_case_name(input):
+    if '_' in input:
+        return False
+
+    if input.islower():
+        return False
+
+    if input.isupper():
+        return False
+
+    return True

--- a/generator/camel_case_splitter.py
+++ b/generator/camel_case_splitter.py
@@ -13,17 +13,12 @@ def split_camel_case(input):
 
     underscore_split = input.split("_")
     retval = ""
-    should_be_upper = False
     for i in underscore_split:
-        if i.isupper():
-            should_be_upper = True
         if is_camel_case_name(i):
             retval += remove_camel_case(i) + "_"
         else:
             retval += i + "_"
 
-    if should_be_upper:
-        retval = retval.upper()
     return retval[:-1].replace("__", "_")
 
 

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -458,7 +458,7 @@ class Field:
         if self.default is None:
             return None
 
-        ctype = self.ctype
+        ctype = self.ctype_t
         default = self.get_initializer(False, True)
         array_decl = ''
 

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -176,11 +176,11 @@ class Enum:
         self.names_upper = str(self.names).upper()
 
         if enum_options.long_names:
-            self.values = [(self.names + x.name, x.number) for x in desc.value]
+            self.values = [(str(self.names + x.name).upper(), x.number) for x in desc.value]
         else:
-            self.values = [(names + x.name, x.number) for x in desc.value]
+            self.values = [(str(names + x.name).upper(), x.number) for x in desc.value]
 
-        self.value_longnames = [self.names + x.name for x in desc.value]
+        self.value_longnames = [str(self.names + x.name).upper() for x in desc.value]
         self.packed = enum_options.packed_enum
 
     def has_negative(self):
@@ -425,7 +425,7 @@ class Field:
             elif self.pbtype in ['SFIXED64', 'INT64']:
                 inner_init = str(self.default) + 'll'
             else:
-                inner_init = str(self.default)
+                inner_init = str(self.default).upper()
 
         if inner_init_only:
             return inner_init

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -424,8 +424,10 @@ class Field:
                 inner_init = str(self.default) + 'ull'
             elif self.pbtype in ['SFIXED64', 'INT64']:
                 inner_init = str(self.default) + 'll'
-            else:
+            elif self.pbtype in ('ENUM', 'UENUM'):
                 inner_init = str(self.default).upper()
+            else:
+                inner_init = str(self.default)
 
         if inner_init_only:
             return inner_init

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -80,6 +80,8 @@ try:
 except NameError:
     strtypes = (str, )
 
+from camel_case_splitter import split_camel_case
+
 class Names:
     '''Keeps a set of nested names and formats them to C identifier.'''
     def __init__(self, parts = ()):
@@ -88,7 +90,8 @@ class Names:
         self.parts = tuple(parts)
 
     def __str__(self):
-        return '_'.join(self.parts)
+        name_str = '_'.join(self.parts)
+        return split_camel_case(name_str)
 
     def __add__(self, other):
         if isinstance(other, strtypes):
@@ -169,6 +172,8 @@ class Enum:
 
         self.options = enum_options
         self.names = names + desc.name
+        self.names_t = self.names + "_t"
+        self.names_upper = str(self.names).upper()
 
         if enum_options.long_names:
             self.values = [(self.names + x.name, x.number) for x in desc.value]
@@ -188,18 +193,19 @@ class Enum:
         return max([varint_max_size(v) for n,v in self.values])
 
     def __str__(self):
-        result = 'typedef enum _%s {\n' % self.names
+        # result = 'typedef enum _%s {\n' % self.names_t
+        result = 'typedef enum\n{\n'
         result += ',\n'.join(["    %s = %d" % x for x in self.values])
         result += '\n}'
 
         if self.packed:
             result += ' pb_packed'
 
-        result += ' %s;' % self.names
+        result += ' %s;' % self.names_t
 
-        result += '\n#define _%s_MIN %s' % (self.names, self.values[0][0])
-        result += '\n#define _%s_MAX %s' % (self.names, self.values[-1][0])
-        result += '\n#define _%s_ARRAYSIZE ((%s)(%s+1))' % (self.names, self.names, self.values[-1][0])
+        result += '\n#define %s_MIN %s' % (self.names_upper, self.values[0][0])
+        result += '\n#define %s_MAX %s' % (self.names_upper, self.values[-1][0])
+        result += '\n#define %s_ARRAYSIZE ((%s)(%s+1))' % (self.names_upper, str(self.names_t), self.values[-1][0])
 
         if not self.options.long_names:
             # Define the long names always so that enum value references
@@ -240,6 +246,7 @@ class Field:
         self.array_decl = ""
         self.enc_size = None
         self.ctype = None
+        self.ctype_t = None
 
         # Parse field options
         if field_options.HasField("max_size"):
@@ -297,21 +304,26 @@ class Field:
         # Decide the C data type to use in the struct.
         if desc.type in datatypes:
             self.ctype, self.pbtype, self.enc_size, isa = datatypes[desc.type]
+            self.ctype_t = self.ctype
 
             # Override the field size if user wants to use smaller integers
             if isa and field_options.int_size != nanopb_pb2.IS_DEFAULT:
                 self.ctype = intsizes[field_options.int_size]
+                self.ctype_t = self.ctype
                 if desc.type == FieldD.TYPE_UINT32 or desc.type == FieldD.TYPE_UINT64:
                     self.ctype = 'u' + self.ctype;
+                    self.ctype_t = self.ctype
         elif desc.type == FieldD.TYPE_ENUM:
             self.pbtype = 'ENUM'
             self.ctype = names_from_type_name(desc.type_name)
+            self.ctype_t = self.ctype + "_t"
             if self.default is not None:
                 self.default = self.ctype + self.default
             self.enc_size = None # Needs to be filled in when enum values are known
         elif desc.type == FieldD.TYPE_STRING:
             self.pbtype = 'STRING'
             self.ctype = 'char'
+            self.ctype_t = self.ctype
             if self.allocation == 'STATIC':
                 self.ctype = 'char'
                 self.array_decl += '[%d]' % self.max_size
@@ -320,12 +332,15 @@ class Field:
             self.pbtype = 'BYTES'
             if self.allocation == 'STATIC':
                 self.ctype = self.struct_name + self.name + 't'
+                self.ctype_t = self.ctype
                 self.enc_size = varint_max_size(self.max_size) + self.max_size
             elif self.allocation == 'POINTER':
                 self.ctype = 'pb_bytes_array_t'
+                self.ctype_t = self.ctype
         elif desc.type == FieldD.TYPE_MESSAGE:
             self.pbtype = 'MESSAGE'
             self.ctype = self.submsgname = names_from_type_name(desc.type_name)
+            self.ctype_t = self.ctype + "_t"
             self.enc_size = None # Needs to be filled in after the message type is available
         else:
             raise NotImplementedError(desc.type)
@@ -341,12 +356,12 @@ class Field:
 
             if self.pbtype == 'MESSAGE':
                 # Use struct definition, so recursive submessages are possible
-                result += '    struct _%s *%s;' % (self.ctype, self.name)
+                result += '    struct _%s *%s;' % (self.ctype_t, self.name)
             elif self.rules == 'REPEATED' and self.pbtype in ['STRING', 'BYTES']:
                 # String/bytes arrays need to be defined as pointers to pointers
-                result += '    %s **%s;' % (self.ctype, self.name)
+                result += '    %s **%s;' % (self.ctype_t, self.name)
             else:
-                result += '    %s *%s;' % (self.ctype, self.name)
+                result += '    %s *%s;' % (self.ctype_t, self.name)
         elif self.allocation == 'CALLBACK':
             result += '    pb_callback_t %s;' % self.name
         else:
@@ -354,7 +369,7 @@ class Field:
                 result += '    bool has_' + self.name + ';\n'
             elif self.rules == 'REPEATED' and self.allocation == 'STATIC':
                 result += '    pb_size_t ' + self.name + '_count;\n'
-            result += '    %s %s%s;' % (self.ctype, self.name, self.array_decl)
+            result += '    %s %s%s;' % (self.ctype_t, self.name, self.array_decl)
         return result
 
     def types(self):
@@ -390,7 +405,7 @@ class Field:
             elif self.pbtype == 'BYTES':
                 inner_init = '{0, {0}}'
             elif self.pbtype in ('ENUM', 'UENUM'):
-                inner_init = '(%s)0' % self.ctype
+                inner_init = '(%s)0' % self.ctype_t
             else:
                 inner_init = '0'
         else:
@@ -462,7 +477,7 @@ class Field:
 
     def tags(self):
         '''Return the #define for the tag number of this field.'''
-        identifier = '%s_%s_tag' % (self.struct_name, self.name)
+        identifier = ('%s_%s_tag' % (self.struct_name, self.name)).upper()
         return '#define %-40s %d\n' % (identifier, self.tag)
 
     def pb_field_t(self, prev_field_name):
@@ -483,12 +498,12 @@ class Field:
         result += '%s, ' % self.rules
         result += '%-8s, ' % self.allocation
         result += '%s, ' % ("FIRST" if not prev_field_name else "OTHER")
-        result += '%s, ' % self.struct_name
+        result += '%s, ' % (str(self.struct_name) + "_t")
         result += '%s, ' % self.name
         result += '%s, ' % (prev_field_name or self.name)
 
         if self.pbtype == 'MESSAGE':
-            result += '&%s_fields)' % self.submsgname
+            result += '&%s_fields)' % str(self.submsgname)
         elif self.default is None:
             result += '0)'
         elif self.pbtype in ['BYTES', 'STRING'] and self.allocation != 'STATIC':
@@ -509,14 +524,14 @@ class Field:
         check = []
         if self.pbtype == 'MESSAGE':
             if self.rules == 'REPEATED' and self.allocation == 'STATIC':
-                check.append('pb_membersize(%s, %s[0])' % (self.struct_name, self.name))
+                check.append('pb_membersize(%s, %s[0])' % (self.struct_name+"_t", self.name))
             elif self.rules == 'ONEOF':
                 if self.anonymous:
-                    check.append('pb_membersize(%s, %s)' % (self.struct_name, self.name))
+                    check.append('pb_membersize(%s, %s)' % (self.struct_name+"_t", self.name))
                 else:
-                    check.append('pb_membersize(%s, %s.%s)' % (self.struct_name, self.union_name, self.name))
+                    check.append('pb_membersize(%s, %s.%s)' % (self.struct_name+"_t", self.union_name, self.name))
             else:
-                check.append('pb_membersize(%s, %s)' % (self.struct_name, self.name))
+                check.append('pb_membersize(%s, %s)' % (self.struct_name+"_t", self.name))
 
         return FieldMaxSize([self.tag, self.max_size, self.max_count],
                             check,
@@ -624,7 +639,7 @@ class ExtensionField(Field):
 
     def tags(self):
         '''Return the #define for the tag number of this field.'''
-        identifier = '%s_tag' % self.fullname
+        identifier = ('%s_tag' % self.fullname).upper()
         return '#define %-40s %d\n' % (identifier, self.tag)
 
     def extension_decl(self):
@@ -645,7 +660,7 @@ class ExtensionField(Field):
 
         result  = 'typedef struct {\n'
         result += str(self)
-        result += '\n} %s;\n\n' % self.struct_name
+        result += '\n} %s_t;\n\n' % self.struct_name
         result += ('static const pb_field_t %s_field = \n  %s;\n\n' %
                     (self.fullname, self.pb_field_t(None)))
         result += 'const pb_extension_type_t %s = {\n' % self.fullname
@@ -755,6 +770,7 @@ class OneOf(Field):
 class Message:
     def __init__(self, names, desc, message_options):
         self.name = names
+        self.name_t = self.name + "_t"
         self.fields = []
         self.oneofs = {}
         no_unions = []
@@ -808,21 +824,21 @@ class Message:
         return deps
 
     def __str__(self):
-        result = 'typedef struct _%s {\n' % self.name
+        # result = 'typedef struct _%s {\n' % self.name_t
+        result = 'typedef struct {\n'
 
         if not self.ordered_fields:
             # Empty structs are not allowed in C standard.
             # Therefore add a dummy field if an empty message occurs.
             result += '    char dummy_field;'
-
         result += '\n'.join([str(f) for f in self.ordered_fields])
-        result += '\n/* @@protoc_insertion_point(struct:%s) */' % self.name
+        result += '\n/* @@protoc_insertion_point(struct:%s) */' % self.name_t
         result += '\n}'
 
         if self.packed:
             result += ' pb_packed'
 
-        result += ' %s;' % self.name
+        result += ' %s;' % self.name_t
 
         if self.packed:
             result = 'PB_PACKED_STRUCT_START\n' + result
@@ -839,7 +855,17 @@ class Message:
 
         parts = []
         for field in self.ordered_fields:
-            parts.append(field.get_initializer(null_init))
+            to_append = ''
+            for i in field.get_initializer(null_init).split(', '):
+                if 'init_default' in i or 'init_zero' in i:
+                    to_append += i.upper()
+                else:
+                    to_append += i
+                to_append += ", "
+
+            to_append = to_append[:-2]
+
+            parts.append(to_append)
         return '{' + ', '.join(parts) + '}'
 
     def default_decl(self, declaration_only = False):
@@ -1096,10 +1122,10 @@ class ProtoFile:
 
             yield '/* Initializer values for message structs */\n'
             for msg in self.messages:
-                identifier = '%s_init_default' % msg.name
+                identifier = ('%s_init_default' % msg.name).upper()
                 yield '#define %-40s %s\n' % (identifier, msg.get_initializer(False))
             for msg in self.messages:
-                identifier = '%s_init_zero' % msg.name
+                identifier = ('%s_init_zero' % msg.name).upper()
                 yield '#define %-40s %s\n' % (identifier, msg.get_initializer(True))
             yield '\n'
 
@@ -1119,9 +1145,9 @@ class ProtoFile:
             yield '/* Maximum encoded size of messages (where known) */\n'
             for msg in self.messages:
                 msize = msg.encoded_size(self.dependencies)
-                identifier = '%s_size' % msg.name
+                identifier = ('%s_size' % msg.name).upper()
                 if msize is not None:
-                    yield '#define %-40s %s\n' % (identifier, msize)
+                    yield '#define %-40s %s\n' % (identifier, str(msize).upper())
                 else:
                     yield '/* %s depends on runtime parameters */\n' % identifier
             yield '\n'

--- a/tests/alltypes/decode_alltypes.c
+++ b/tests/alltypes/decode_alltypes.c
@@ -173,7 +173,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(alltypes.opt_enum == MY_ENUM_TRUTH);
         TEST(alltypes.has_opt_emptymsg  == true);
 
-        TEST(alltypes.which_oneof == all_types_t_oneof_msg1_tag);
+        TEST(alltypes.which_oneof == ALL_TYPES_ONEOF_MSG1_TAG);
         TEST(strcmp(alltypes.oneof.oneof_msg1.substuff1, "4059") == 0);
         TEST(alltypes.oneof.oneof_msg1.substuff2 == 4059);
     }

--- a/tests/alltypes/decode_alltypes.c
+++ b/tests/alltypes/decode_alltypes.c
@@ -20,13 +20,13 @@
 bool check_alltypes(pb_istream_t *stream, int mode)
 {
     /* Uses _init_default to just make sure that it works. */
-    AllTypes alltypes = AllTypes_init_default;
+    all_types_t alltypes = ALL_TYPES_INIT_DEFAULT;
     
     /* Fill with garbage to better detect initialization errors */
     memset(&alltypes, 0xAA, sizeof(alltypes));
     alltypes.extensions = 0;
     
-    if (!pb_decode(stream, AllTypes_fields, &alltypes))
+    if (!pb_decode(stream, all_types_fields, &alltypes))
         return false;
     
     TEST(alltypes.req_int32         == -1001);
@@ -51,7 +51,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(strcmp(alltypes.req_submsg.substuff1, "1016") == 0);
     TEST(alltypes.req_submsg.substuff2 == 1016);
     TEST(alltypes.req_submsg.substuff3 == 3);
-    TEST(alltypes.req_enum == MyEnum_Truth);
+    TEST(alltypes.req_enum == MY_ENUM_TRUTH);
     
     TEST(alltypes.rep_int32_count == 5 && alltypes.rep_int32[4] == -2001 && alltypes.rep_int32[0] == 0);
     TEST(alltypes.rep_int64_count == 5 && alltypes.rep_int64[4] == -2002 && alltypes.rep_int64[0] == 0);
@@ -78,7 +78,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(alltypes.rep_submsg[4].substuff2 == 2016 && alltypes.rep_submsg[0].substuff2 == 0);
     TEST(alltypes.rep_submsg[4].substuff3 == 2016 && alltypes.rep_submsg[0].substuff3 == 3);
     
-    TEST(alltypes.rep_enum_count == 5 && alltypes.rep_enum[4] == MyEnum_Truth && alltypes.rep_enum[0] == MyEnum_Zero);
+    TEST(alltypes.rep_enum_count == 5 && alltypes.rep_enum[4] == MY_ENUM_TRUTH && alltypes.rep_enum[0] == MY_ENUM_ZERO);
     TEST(alltypes.rep_emptymsg_count == 5);
     
     if (mode == 0)
@@ -123,7 +123,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(alltypes.opt_submsg.substuff2 == 2);
         TEST(alltypes.opt_submsg.substuff3 == 3);
         TEST(alltypes.has_opt_enum     == false);
-        TEST(alltypes.opt_enum == MyEnum_Second);
+        TEST(alltypes.opt_enum == MY_ENUM_SECOND);
         TEST(alltypes.has_opt_emptymsg == false);
 
         TEST(alltypes.which_oneof == 0);
@@ -170,10 +170,10 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(alltypes.opt_submsg.substuff2 == 3056);
         TEST(alltypes.opt_submsg.substuff3 == 3);
         TEST(alltypes.has_opt_enum      == true);
-        TEST(alltypes.opt_enum == MyEnum_Truth);
+        TEST(alltypes.opt_enum == MY_ENUM_TRUTH);
         TEST(alltypes.has_opt_emptymsg  == true);
 
-        TEST(alltypes.which_oneof == AllTypes_oneof_msg1_tag);
+        TEST(alltypes.which_oneof == all_types_t_oneof_msg1_tag);
         TEST(strcmp(alltypes.oneof.oneof_msg1.substuff1, "4059") == 0);
         TEST(alltypes.oneof.oneof_msg1.substuff2 == 4059);
     }
@@ -186,8 +186,8 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(alltypes.req_limits.int64_max  == INT64_MAX);
     TEST(alltypes.req_limits.uint64_min == 0);
     TEST(alltypes.req_limits.uint64_max == UINT64_MAX);
-    TEST(alltypes.req_limits.enum_min   == HugeEnum_Negative);
-    TEST(alltypes.req_limits.enum_max   == HugeEnum_Positive);
+    TEST(alltypes.req_limits.enum_min   == HUGE_ENUM_NEGATIVE);
+    TEST(alltypes.req_limits.enum_max   == HUGE_ENUM_POSITIVE);
     
     TEST(alltypes.end == 1099);
     

--- a/tests/alltypes/encode_alltypes.c
+++ b/tests/alltypes/encode_alltypes.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
     alltypes.end = 1099;
     
     {
-        uint8_t buffer[all_types_t_size];
+        uint8_t buffer[ALL_TYPES_SIZE];
         pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
         
         /* Now encode it and check if we succeeded. */

--- a/tests/alltypes/encode_alltypes.c
+++ b/tests/alltypes/encode_alltypes.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
     int mode = (argc > 1) ? atoi(argv[1]) : 0;
     
     /* Initialize the structure with constants */
-    AllTypes alltypes = AllTypes_init_zero;
+    all_types_t alltypes = ALL_TYPES_INIT_ZERO;
     
     alltypes.req_int32         = -1001;
     alltypes.req_int64         = -1002;
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     memcpy(alltypes.req_bytes.bytes, "1015", 4);
     strcpy(alltypes.req_submsg.substuff1, "1016");
     alltypes.req_submsg.substuff2 = 1016;
-    alltypes.req_enum = MyEnum_Truth;
+    alltypes.req_enum = MY_ENUM_TRUTH;
     
     alltypes.rep_int32_count = 5; alltypes.rep_int32[4] = -2001;
     alltypes.rep_int64_count = 5; alltypes.rep_int64[4] = -2002;
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     alltypes.rep_submsg[4].has_substuff3 = true;
     alltypes.rep_submsg[4].substuff3 = 2016;
     
-    alltypes.rep_enum_count = 5; alltypes.rep_enum[4] = MyEnum_Truth;
+    alltypes.rep_enum_count = 5; alltypes.rep_enum[4] = MY_ENUM_TRUTH;
     alltypes.rep_emptymsg_count = 5;
     
     alltypes.req_limits.int32_min  = INT32_MIN;
@@ -75,8 +75,8 @@ int main(int argc, char **argv)
     alltypes.req_limits.int64_max  = INT64_MAX;
     alltypes.req_limits.uint64_min = 0;
     alltypes.req_limits.uint64_max = UINT64_MAX;
-    alltypes.req_limits.enum_min   = HugeEnum_Negative;
-    alltypes.req_limits.enum_max   = HugeEnum_Positive;
+    alltypes.req_limits.enum_min   = HUGE_ENUM_NEGATIVE;
+    alltypes.req_limits.enum_max   = HUGE_ENUM_POSITIVE;
     
     if (mode != 0)
     {
@@ -119,10 +119,10 @@ int main(int argc, char **argv)
         strcpy(alltypes.opt_submsg.substuff1, "3056");
         alltypes.opt_submsg.substuff2 = 3056;
         alltypes.has_opt_enum = true;
-        alltypes.opt_enum = MyEnum_Truth;
+        alltypes.opt_enum = MY_ENUM_TRUTH;
         alltypes.has_opt_emptymsg = true;
 
-        alltypes.which_oneof = AllTypes_oneof_msg1_tag;
+        alltypes.which_oneof = ALL_TYPES_ONEOF_MSG1_TAG;
         strcpy(alltypes.oneof.oneof_msg1.substuff1, "4059");
         alltypes.oneof.oneof_msg1.substuff2 = 4059;
     }
@@ -130,11 +130,11 @@ int main(int argc, char **argv)
     alltypes.end = 1099;
     
     {
-        uint8_t buffer[AllTypes_size];
+        uint8_t buffer[all_types_t_size];
         pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
         
         /* Now encode it and check if we succeeded. */
-        if (pb_encode(&stream, AllTypes_fields, &alltypes))
+        if (pb_encode(&stream, all_types_fields, &alltypes))
         {
             SET_BINARY_MODE(stdout);
             fwrite(buffer, 1, stream.bytes_written, stdout);


### PR DESCRIPTION
The Protocol Buffers [guidlines](https://developers.google.com/protocol-buffers/docs/style) recommend using CamelCase for Enums, Messages and Services.
The current version of nanopb does not convert them to C style, but rather leaves some strange looking C code like:

```C
typedef struct _namespace_SomeMessage {
   namespace_Type some_value;
} namespace_SomeMessage;
```

This commit fixes this issue. It also uppercases the #define names for intt_defaults, tags, max size, and others.

The generated code look now like that:
```C
typedef enum
{
    NAMESPACE_TYPE_FIRST = 0,
    NAMESPACE_TYPE_SECOND = 1
} namespace_type_t;
#define NAMESPACE_TYPE_MIN NAMESPACE_TYPE_FIRST 
#define NAMESPACE_TYPE_MAX  NAMESPACE_TYPE_SECOND
#define NAMESPACE_TYPE_ARRAYSIZE ((namespace_type_t)(NAMESPACE_TYPE_SECOND+1))

typedef struct {
  namespace_type_t some_value;
/* @@protoc_insertion_point(struct:namespace_some_message_t) */
} namespace_some_message_t;

// etc.
#define NAMESPACE_MESSAGE_SIZE                            4
```

I've tested it with messages, enums, oneofs, extensions, required and optional, repeated, *max_length* and *max_size* defined in an options file, default values (numeric or enums). The C na H files compile every time without problems with pb.h version 30.

Example proto file:
```proto
package namespace;

enum Type {
  FIRST = 0;
  SECOND = 1;
}
message SomeMessage {
  required Type some_value = 1;
}
```

**Note:** The commit also removes the *_enum_name* and *_struct_name* from enums and structs definitions, but to add it again you can just uncomment it.
The commit also includes the hardcoded **_t** for enums and structs names.

This commit will break compatibility with previously generated code as type names and defines will change.

Also, I didn't try to build an .exe file from it.
Changes made by me and @hakonfam due to #199.