### PR TITLE
Fix bad pointer dereference with static repeated submessages

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1034,13 +1034,13 @@ static void pb_release_single_field(const pb_field_iter_t *iter)
         
         if (PB_HTYPE(type) == PB_HTYPE_REPEATED)
         {
-            if(PB_ATYPE(type) == PB_ATYPE_POINTER)
-            {
-                count = *(pb_size_t*)iter->pSize;
-            }
-            else if(PB_ATYPE(type) == PB_ATYPE_STATIC)
+            if(PB_ATYPE(type) == PB_ATYPE_STATIC)
             {
                 count = iter->pos->array_size;
+            }
+            else
+            {
+                count = *(pb_size_t*)iter->pSize;
             }
         }
         

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1034,7 +1034,14 @@ static void pb_release_single_field(const pb_field_iter_t *iter)
         
         if (PB_HTYPE(type) == PB_HTYPE_REPEATED)
         {
-            count = *(pb_size_t*)iter->pSize;
+            if(PB_ATYPE(type) == PB_ATYPE_POINTER)
+            {
+                count = *(pb_size_t*)iter->pSize;
+            }
+            else if(PB_ATYPE(type) == PB_ATYPE_STATIC)
+            {
+                count = iter->pos->array_size;
+            }
         }
         
         if (pItem)


### PR DESCRIPTION
**Steps to reproduce the issue**

1. Have a repeated submessage inside a message, all of which are set to `type:FT_STATIC`
2. Call pb_release on the main message

**What happens?**
Read access violation when attempting to get the count of the submessage

**What should happen?**
Successful pb_release (basically a no-op for static fields, right?)

I believe this issue was introduced as a part of 88b2efe0477f4f9e313b5d7307dfd347b6893376. Let me know if this doesn't seem like the correct fix; I admit that I'm a little fuzzy about nanopb internals.