### PR TITLE
RFC: Add "implicit has" option for optional messages

### DIFF
--- a/generator/proto/nanopb.proto
+++ b/generator/proto/nanopb.proto
@@ -66,6 +66,9 @@ message NanoPBOptions {
 
   // decode oneof as anonymous union
   optional bool anonymous_oneof = 11 [default = false];
+
+  // Optional field does not generate a "has_" flag
+  optional bool optional_implicit_has = 12 [default = false];
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options

--- a/pb.h
+++ b/pb.h
@@ -413,6 +413,10 @@ struct pb_extension_s {
     pb_delta(st, has_ ## m, m), \
     pb_membersize(st, m), 0, ptr}
 
+#define PB_OPTIONAL_IMPLICIT_STATIC(tag, st, m, fd, ltype, ptr) \
+    {tag, PB_ATYPE_STATIC | PB_HTYPE_OPTIONAL | ltype, \
+    fd, 0, pb_membersize(st, m), 0, ptr}
+
 /* Repeated fields have a _count field and also the maximum number of entries. */
 #define PB_REPEATED_STATIC(tag, st, m, fd, ltype, ptr) \
     {tag, PB_ATYPE_STATIC | PB_HTYPE_REPEATED | ltype, \

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -360,7 +360,8 @@ static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t
             return func(stream, iter->pos, iter->pData);
             
         case PB_HTYPE_OPTIONAL:
-            *(bool*)iter->pSize = true;
+            if (iter->pSize != iter->pData)
+                *(bool*)iter->pSize = true;
             return func(stream, iter->pos, iter->pData);
     
         case PB_HTYPE_REPEATED:
@@ -772,7 +773,8 @@ static void pb_field_set_to_default(pb_field_iter_t *iter)
         {
             /* Set has_field to false. Still initialize the optional field
              * itself also. */
-            *(bool*)iter->pSize = false;
+            if (iter->pSize != iter->pData)
+                *(bool*)iter->pSize = false;
         }
         else if (PB_HTYPE(type) == PB_HTYPE_REPEATED ||
                  PB_HTYPE(type) == PB_HTYPE_ONEOF)


### PR DESCRIPTION
I am using nanopb in an embedded project for storage of nonvolatile data to flash.  In this application, I would like for the users of the data to be able to assume that values in nonvol-backed structs are current and valid, and that changes they make to the structs will be automatically backed up to nonvol at shutdown.  I do not want to push the responsibility of checking and setting a lot of "has_xxx" fields onto the users of this data.

I am using protobuf for the ease of encoding and decoding this data, especially where fields can be added and removed from version to version of firmware.  When a new field is added, it gets loaded to its default value, and all the old nonvol values are retained.  All fields in my protobuf structs are "optional", so that you can upgrade and downgrade versions without trouble.

This change adds an "optional_implicit_has" nanopb option.  For any field with this set to "true", it does not generate the "has_" field, and always assumes that the field is present when encoding.  When decoding, if the field is not present, it is set to default like usual.  Since we must have enough flash to store all values, the larger encoding size of "implicit_has" does not make a difference.

This is mostly a proof-of-concept.  I am glad to change anything related to coding style, naming, etc.  Please let me know what you think, and if this is a valuable addition to upstream.