### PR TITLE
Make pb_field_t void* member pointer size aligned

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -241,7 +241,7 @@ struct pb_field_s {
     /* Field definitions for submessage
      * OR default value for all other non-array, non-callback types
      * If null, then field will zeroed. */
-    const void *ptr;
+    const void *ptr __attribute__((aligned(sizeof(void*))));
 } pb_packed;
 PB_PACKED_STRUCT_END
 


### PR DESCRIPTION
For some reason the linker will zero-out these pointer values at
link time if this is not aligned properly to store a 64bit pointer on powerpc.