### PR TITLE
Fix potential unaligned access

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -220,11 +220,15 @@ static bool checkreturn encode_basic_field(pb_ostream_t *stream,
             if(bytes->size == 0)
                 implicit_has = false;
         }
-        else if ((PB_LTYPE(field->type) == PB_LTYPE_STRING && *(const char*)pData == '\0') ||
-                (field->data_size == sizeof(uint_least8_t) && *(const uint_least8_t*)pData == 0) ||
-                (field->data_size == sizeof(uint_least16_t) && *(const uint_least16_t*)pData == 0) ||
-                (field->data_size == sizeof(uint32_t) && *(const uint_least32_t*)pData == 0) ||
-                (field->data_size == sizeof(uint64_t) && *(const uint_least64_t*)pData == 0))                   
+        else if (PB_LTYPE(field->type) == PB_LTYPE_STRING )
+        {
+        	if( *(const char*)pData == '\0')
+				 implicit_has = false;
+        }
+		else if ((field->data_size == sizeof(uint_least8_t) && *(const uint_least8_t*)pData == 0) ||
+                 (field->data_size == sizeof(uint_least16_t) && *(const uint_least16_t*)pData == 0) ||
+                 (field->data_size == sizeof(uint32_t) && *(const uint_least32_t*)pData == 0) ||
+		         (field->data_size == sizeof(uint64_t) && *(const uint_least64_t*)pData == 0))
         {                   
             implicit_has = false;
         }


### PR DESCRIPTION
Hello,

**What happens ?**
When trying to use nanopb on ARMv4 I came across a trap when encoding a message. I figured out that an unaligned access cause this. 

**How to reproduce the problem**
This occur only when you have a string of `size == sizeof(uint64_t)` and the data pointer is not aligned to a 64bit boundary.

If the type is string, do not try to deference it as int16, int32 or int64.
This may lead to unalign memory access, which may cause trap on some architectures (ARM)