### PR TITLE
Fix closing a non-empty substream resulting in an incorrect stream state

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -11,6 +11,19 @@ are included, in order to make it easier to find this document.
 
 .. contents ::
 
+Nanopb-0.3.8 (2017-xx-xx)
+=========================
+Fully drain substreams before closing
+
+**Rationale:** If the substream functions were called directly and the caller
+did not completely empty the substring before closing it, the parent stream
+would be put into an incorrect state.
+
+**Changes:** *pb_close_string_substream* can now error and returns a boolean.
+
+**Required actions:** Add error checking onto any call to
+*pb_close_string_substream*.
+
 Nanopb-0.3.5 (2016-02-13)
 =========================
 

--- a/pb_decode.h
+++ b/pb_decode.h
@@ -144,7 +144,7 @@ bool pb_decode_fixed64(pb_istream_t *stream, void *dest);
 
 /* Make a limited-length substream for reading a PB_WT_STRING field. */
 bool pb_make_string_substream(pb_istream_t *stream, pb_istream_t *substream);
-void pb_close_string_substream(pb_istream_t *stream, pb_istream_t *substream);
+bool pb_close_string_substream(pb_istream_t *stream, pb_istream_t *substream);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
If pb_close_string_substream is called on a non-empty substream bytes_left will end up being decreased by more than what was actually read. This commit checks and empties out the substream first if it's non-empty.

Not a problem unless you're calling the substream functions yourself since nanopb itself always exhausts the stream before closing, but probably not the intended behaviour.