### PR TITLE
CMAKE: remove use of relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,12 @@ if(nanopb_BUILD_GENERATOR)
         string(REGEX REPLACE "([^;]+)" "\\1_pb2.py" generator_proto_py_file "${generator_proto}")
         add_custom_command(
             OUTPUT ${generator_proto_py_file}
-            COMMAND protoc --python_out=${CMAKE_CURRENT_BINARY_DIR} -I${PROJECT_SOURCE_DIR}/generator/proto ${generator_proto_file}
+            COMMAND protoc --python_out=${PROJECT_BINARY_DIR} -I${PROJECT_SOURCE_DIR}/generator/proto ${generator_proto_file}
             DEPENDS ${generator_proto_file}
         )
         add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})
         install(
-            FILES ${generator_proto_py_file}
+            FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
 			DESTINATION ${PYTHON_INSTDIR}
         )
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,11 @@ if(nanopb_BUILD_GENERATOR)
     )
 
     foreach(generator_proto IN LISTS generator_protos)
-        string(REGEX REPLACE "([^;]+)" "generator/proto/\\1.proto" generator_proto_file "${generator_proto}")
+        string(REGEX REPLACE "([^;]+)" "${PROJECT_SOURCE_DIR}/generator/proto/\\1.proto" generator_proto_file "${generator_proto}")
         string(REGEX REPLACE "([^;]+)" "\\1_pb2.py" generator_proto_py_file "${generator_proto}")
         add_custom_command(
             OUTPUT ${generator_proto_py_file}
-            COMMAND protoc --python_out=${CMAKE_CURRENT_BINARY_DIR} -Igenerator/proto ${generator_proto_file}
+            COMMAND protoc --python_out=${CMAKE_CURRENT_BINARY_DIR} -I${PROJECT_SOURCE_DIR}/generator/proto ${generator_proto_file}
             DEPENDS ${generator_proto_file}
         )
         add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})


### PR DESCRIPTION
When doing out of source builds:

mkdir build
cd build && cmake -G "Unix Makefiles" ../ && make

The build script tripped up on relative paths of /generator/proto and
the files under generator/proto/*.proto.

By using ${PROJECT_SOURCE_DIR}, the paths become absolute and the issue
disappears.