### PR TITLE
Add pb_encode_varint32 and pb_encode_svarint32

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -524,6 +524,49 @@ bool checkreturn pb_encode_svarint(pb_ostream_t *stream, int64_t value)
     return pb_encode_varint(stream, zigzagged);
 }
 
+bool checkreturn pb_encode_varint32(pb_ostream_t *stream, uint32_t value)
+{
+    pb_byte_t buffer[5];
+    
+    if (value < (1 << 7)) {
+      buffer[0] = (pb_byte_t)value;
+      return pb_write(stream, buffer, 1);
+    } else if ((value >> 14) == 0) {
+      buffer[0] = (pb_byte_t)(value | 0x80);
+      buffer[1] = (pb_byte_t)(value >> 7);
+      return pb_write(stream, buffer, 2);
+    } else if ((value >> 21) == 0) {
+      buffer[0] = (pb_byte_t)(value | 0x80);
+      buffer[1] = (pb_byte_t)((value >> 7) | 0x80);
+      buffer[2] = (pb_byte_t)(value >> 14);
+      return pb_write(stream, buffer, 3);
+    } else if ((value >> 28) == 0) {
+      buffer[0] = (pb_byte_t)(value | 0x80);
+      buffer[1] = (pb_byte_t)((value >> 7) | 0x80);
+      buffer[2] = (pb_byte_t)((value >> 14) | 0x80);
+      buffer[3] = (pb_byte_t)(value >> 21);
+      return pb_write(stream, buffer, 4);
+    } else {
+      buffer[0] = (pb_byte_t)(value | 0x80);
+      buffer[1] = (pb_byte_t)((value >> 7) | 0x80);
+      buffer[2] = (pb_byte_t)((value >> 14) | 0x80);
+      buffer[3] = (pb_byte_t)((value >> 21) | 0x80);
+      buffer[4] = (pb_byte_t)(value >> 28);
+      return pb_write(stream, buffer, 5);
+    }
+}
+
+bool checkreturn pb_encode_svarint32(pb_ostream_t *stream, int32_t value)
+{
+    uint32_t zigzagged;
+    if (value < 0)
+        zigzagged = ~((uint32_t)value << 1);
+    else
+        zigzagged = (uint32_t)value << 1;
+    
+    return pb_encode_varint32(stream, zigzagged);
+}
+
 bool checkreturn pb_encode_fixed32(pb_ostream_t *stream, const void *value)
 {
     uint32_t val = *(const uint32_t*)value;

--- a/pb_encode.h
+++ b/pb_encode.h
@@ -125,9 +125,17 @@ bool pb_encode_tag(pb_ostream_t *stream, pb_wire_type_t wiretype, uint32_t field
  * This works for bool, enum, int32, int64, uint32 and uint64 field types. */
 bool pb_encode_varint(pb_ostream_t *stream, uint64_t value);
 
+/* Encode an integer in the varint format.
+ * This works for bool, enum, int32 and uint32 field types. */
+bool pb_encode_varint32(pb_ostream_t *stream, uint32_t value);
+
 /* Encode an integer in the zig-zagged svarint format.
  * This works for sint32 and sint64. */
 bool pb_encode_svarint(pb_ostream_t *stream, int64_t value);
+
+/* Encode an integer in the zig-zagged svarint format.
+ * This works for sint32. */
+bool pb_encode_svarint32(pb_ostream_t *stream, int32_t value);
 
 /* Encode a string or bytes type field. For strings, pass strlen(s) as size. */
 bool pb_encode_string(pb_ostream_t *stream, const pb_byte_t *buffer, size_t size);

--- a/pb_encode.h
+++ b/pb_encode.h
@@ -126,7 +126,9 @@ bool pb_encode_tag(pb_ostream_t *stream, pb_wire_type_t wiretype, uint32_t field
 bool pb_encode_varint(pb_ostream_t *stream, uint64_t value);
 
 /* Encode an integer in the varint format.
- * This works for bool, enum, int32 and uint32 field types. */
+ * This works for bool, enum and uint32 field types.
+ * NOTE: Does not work for int32 since that should encode to 10 bytes to support
+ * promotion to int64 when decoded. */
 bool pb_encode_varint32(pb_ostream_t *stream, uint32_t value);
 
 /* Encode an integer in the zig-zagged svarint format.

--- a/tests/encode_unittests/encode_unittests.c
+++ b/tests/encode_unittests/encode_unittests.c
@@ -86,6 +86,51 @@ int main()
     }
     
     {
+        uint8_t buffer[50];
+        pb_ostream_t s;
+        
+        COMMENT("Test pb_encode_varint32")
+        TEST(WRITES(pb_encode_varint32(&s, 0x00000000), "\x00"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00000001), "\x01"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x0000007F), "\x7F"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00000080), "\x80\x01"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00000191), "\x91\x03"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00003FFF), "\xFF\x7F"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00004000), "\x80\x80\x01"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x0000D111), "\x91\xA2\x03"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x001FFFFF), "\xFF\xFF\x7F"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00200000), "\x80\x80\x80\x01"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x00711111), "\x91\xA2\xC4\x03"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x0FFFFFFF), "\xFF\xFF\xFF\x7F"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x10000000), "\x80\x80\x80\x80\x01"));
+        TEST(WRITES(pb_encode_varint32(&s, 0x31111111), "\x91\xA2\xC4\x88\x03"));
+        TEST(WRITES(pb_encode_varint32(&s, UINT32_MAX), "\xFF\xFF\xFF\xFF\x0F"));
+    }
+    
+    {
+        uint8_t buffer[50];
+        pb_ostream_t s;
+        
+        COMMENT("Test pb_encode_svarint32")
+        TEST(WRITES(pb_encode_svarint32(&s, 0x00000000), "\x00"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0xFFFFFFFF), "\x01"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x0000003F), "\x7E"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0xFFFFFFC0), "\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x00000040), "\x80\x01"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x00001FFF), "\xFE\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0xFFFFE000), "\xFF\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x00002000), "\x80\x80\x01"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x000FFFFF), "\xFE\xFF\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0xFFF00000), "\xFF\xFF\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x00100000), "\x80\x80\x80\x01"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x07FFFFFF), "\xFE\xFF\xFF\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0xF8000000), "\xFF\xFF\xFF\x7F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x08000000), "\x80\x80\x80\x80\x01"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x7FFFFFFF), "\xFE\xFF\xFF\xFF\x0F"));
+        TEST(WRITES(pb_encode_svarint32(&s, 0x80000000), "\xFF\xFF\xFF\xFF\x0F"));
+    }
+    
+    {
         uint8_t buffer[30];
         pb_ostream_t s;
         


### PR DESCRIPTION
Improves performance significantly for 32 bit microcontrollers. I only exposed it as a public API so users can optionally choose whether to use it (since it will slightly increase the binary size).

Below are the profiling results for an ARM CM4F using GCC with -O3.

Original:
pb_encode_varint(0x00000000) == 58 cycles
pb_encode_varint(0x0000007f) == 59 cycles
pb_encode_varint(0x00003fff) == 111 cycles
pb_encode_varint(0x001fffff) == 128 cycles
pb_encode_varint(0x0fffffff) == 143 cycles
pb_encode_varint(0xffffffff) == 157 cycles

pb_encode_svarint(0x00000000) == 62 cycles
pb_encode_svarint(0xffffffff) == 64 cycles
pb_encode_svarint(0x0000003f) == 62 cycles
pb_encode_svarint(0xffffffc0) == 64 cycles
pb_encode_svarint(0x00001fff) == 114 cycles
pb_encode_svarint(0xffffe000) == 116 cycles
pb_encode_svarint(0x000fffff) == 131 cycles
pb_encode_svarint(0xfff00000) == 132 cycles
pb_encode_svarint(0x07ffffff) == 145 cycles
pb_encode_svarint(0xf8000000) == 146 cycles
pb_encode_svarint(0x7fffffff) == 159 cycles
pb_encode_svarint(0x80000000) == 161 cycles

Just switching to 32 bit integers:
pb_encode_varint32(0x00000000) == 36 cycles
pb_encode_varint32(0x0000007f) == 37 cycles
pb_encode_varint32(0x00003fff) == 94 cycles
pb_encode_varint32(0x001fffff) == 107 cycles
pb_encode_varint32(0x0fffffff) == 117 cycles
pb_encode_varint32(0xffffffff) == 122 cycles

pb_encode_svarint32(0x00000000) == 37 cycles
pb_encode_svarint32(0xffffffff) == 35 cycles
pb_encode_svarint32(0x0000003f) == 37 cycles
pb_encode_svarint32(0xffffffc0) == 35 cycles
pb_encode_svarint32(0x00001fff) == 95 cycles
pb_encode_svarint32(0xffffe000) == 93 cycles
pb_encode_svarint32(0x000fffff) == 106 cycles
pb_encode_svarint32(0xfff00000) == 104 cycles
pb_encode_svarint32(0x07ffffff) == 118 cycles
pb_encode_svarint32(0xf8000000) == 116 cycles
pb_encode_svarint32(0x7fffffff) == 122 cycles
pb_encode_svarint32(0x80000000) == 120 cycles

Using cascaded conditionals:
pb_encode_varint32(0x00000000) == 36 cycles
pb_encode_varint32(0x0000007f) == 36 cycles
pb_encode_varint32(0x00003fff) == 55 cycles
pb_encode_varint32(0x001fffff) == 62 cycles
pb_encode_varint32(0x0fffffff) == 69 cycles
pb_encode_varint32(0xffffffff) == 76 cycles

pb_encode_svarint32(0x00000000) == 37 cycles
pb_encode_svarint32(0xffffffff) == 35 cycles
pb_encode_svarint32(0x0000003f) == 37 cycles
pb_encode_svarint32(0xffffffc0) == 35 cycles
pb_encode_svarint32(0x00001fff) == 55 cycles
pb_encode_svarint32(0xffffe000) == 53 cycles
pb_encode_svarint32(0x000fffff) == 64 cycles
pb_encode_svarint32(0xfff00000) == 61 cycles
pb_encode_svarint32(0x07ffffff) == 70 cycles
pb_encode_svarint32(0xf8000000) == 67 cycles
pb_encode_svarint32(0x7fffffff) == 78 cycles
pb_encode_svarint32(0x80000000) == 76 cycles