### PR TITLE
Speed up deocding fixed width integers

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1140,34 +1140,49 @@ bool pb_decode_svarint(pb_istream_t *stream, int64_t *dest)
 
 bool pb_decode_fixed32(pb_istream_t *stream, void *dest)
 {
-    pb_byte_t bytes[4];
+    union {
+        uint32_t fixed32;
+        pb_byte_t bytes[4];
+    } u;
 
-    if (!pb_read(stream, bytes, 4))
+    if (!pb_read(stream, u.bytes, 4))
         return false;
-    
-    *(uint32_t*)dest = ((uint32_t)bytes[0] << 0) |
-                       ((uint32_t)bytes[1] << 8) |
-                       ((uint32_t)bytes[2] << 16) |
-                       ((uint32_t)bytes[3] << 24);
+
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+    /* fast path - if we know that we're on little endian, assign directly */
+    *(uint32_t*)dest = u.fixed32;
+#else
+    *(uint32_t*)dest = ((uint32_t)u.bytes[0] << 0) |
+                       ((uint32_t)u.bytes[1] << 8) |
+                       ((uint32_t)u.bytes[2] << 16) |
+                       ((uint32_t)u.bytes[3] << 24);
+#endif
     return true;
 }
 
 bool pb_decode_fixed64(pb_istream_t *stream, void *dest)
 {
-    pb_byte_t bytes[8];
+    union {
+        uint64_t fixed64;
+        pb_byte_t bytes[8];
+    } u;
 
-    if (!pb_read(stream, bytes, 8))
+    if (!pb_read(stream, u.bytes, 8))
         return false;
-    
-    *(uint64_t*)dest = ((uint64_t)bytes[0] << 0) |
-                       ((uint64_t)bytes[1] << 8) |
-                       ((uint64_t)bytes[2] << 16) |
-                       ((uint64_t)bytes[3] << 24) |
-                       ((uint64_t)bytes[4] << 32) |
-                       ((uint64_t)bytes[5] << 40) |
-                       ((uint64_t)bytes[6] << 48) |
-                       ((uint64_t)bytes[7] << 56);
-    
+
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+    /* fast path - if we know that we're on little endian, assign directly */
+    *(uint64_t*)dest = u.fixed64;
+#else
+    *(uint64_t*)dest = ((uint64_t)u.bytes[0] << 0) |
+                       ((uint64_t)u.bytes[1] << 8) |
+                       ((uint64_t)u.bytes[2] << 16) |
+                       ((uint64_t)u.bytes[3] << 24) |
+                       ((uint64_t)u.bytes[4] << 32) |
+                       ((uint64_t)u.bytes[5] << 40) |
+                       ((uint64_t)u.bytes[6] << 48) |
+                       ((uint64_t)u.bytes[7] << 56);
+#endif
     return true;
 }
 


### PR DESCRIPTION
Remove some unneeded bit-shifting by reading directly to an aligned
buffer.