### PR TITLE
The max size for encoding strings must leave spaces for '\0'

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -769,7 +769,18 @@ static bool checkreturn pb_enc_string(pb_ostream_t *stream, const pb_field_t *fi
     const char *p = (const char*)src;
     
     if (PB_ATYPE(field->type) == PB_ATYPE_POINTER)
+    {
         max_size = (size_t)-1;
+    }
+    else
+    {
+        /* pb_dec_string() assumes string fields end with a null
+         * terminator when the type isn't PB_ATYPE_POINTER, so we
+         * shouldn't allow more than max-1 bytes to be written to
+         * allow space for the null terminator.
+         */
+        max_size -= 1;
+    }
 
     if (src == NULL)
     {

--- a/tests/encode_unittests/encode_unittests.c
+++ b/tests/encode_unittests/encode_unittests.c
@@ -188,7 +188,7 @@ int main()
         value[0] = '\0';
         TEST(WRITES(pb_enc_string(&s, &StringMessage_fields[0], &value), "\x00"))
         memset(value, 'x', 30);
-        TEST(WRITES(pb_enc_string(&s, &StringMessage_fields[0], &value), "\x0Axxxxxxxxxx"))
+        TEST(WRITES(pb_enc_string(&s, &StringMessage_fields[0], &value), "\x09xxxxxxxxx"))
     }
     
     {
@@ -328,7 +328,7 @@ int main()
         COMMENT("Test that StringMessage_size is correct")
 
         TEST(pb_encode(&s, StringMessage_fields, &msg));
-        TEST(s.bytes_written == StringMessage_size);
+        TEST(s.bytes_written == (StringMessage_size - 1));
     }
     
     {


### PR DESCRIPTION
The max size for encoding strings must leave spaces for a null terminator in the case where the field type isn't a pointer. This issue caused a critical bug because the proto was able to encode, but couldn't then decode without the null terminator. 