### PR TITLE
bazel: Add WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name="com_github_nanopb_nanopb")


### PR DESCRIPTION
A WORKSPACE file is required for bazel to build the project. The
conventional naming is similar to Java packages with all special
characters including dots replaced by underscores.