### PR TITLE
Fix Travis-CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,17 @@ before_install:
 #    directories:
 #        - $HOME/protobuf
 
+# Rather then compile protobuf 3 from source, use the binaries now available
+# to speed up build time and reduce surprises until Ubuntu adds protobuf3
+# packages to the repository.
 install:
-    - curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-1/protobuf-python-3.0.0-alpha-4.tar.gz | tar xzf -
-      && pushd protobuf-3.0.0-alpha-4
-      && ./configure --prefix=$HOME/protobuf && make && make install
-      && pushd python && python setup.py build && python setup.py install && popd
+    - mkdir -p $HOME/protobuf && pushd $HOME/protobuf
+      && curl -LO 'https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip'
+      && unzip protoc-3.4.0-linux-x86_64.zip
+      && popd
+    - curl -L 'https://github.com/google/protobuf/releases/download/v3.4.0/protobuf-python-3.4.0.tar.gz' | tar xzf -
+      && pushd protobuf-3.4.0/python
+      && python setup.py build && python setup.py install
       && popd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ install:
 
 script:
     - pushd generator/proto && make && popd
-    - pushd tests && python2 $(which scons) CC=$CC CXX=$CXX && popd
+    - pushd tests && scons CC=$CC CXX=$CXX && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
 
 before_install:
     - export PATH=$HOME/.local/bin:$HOME/protobuf/bin:$PATH
-    - export MAKEFLAGS=-j$(grep processor /proc/cpuinfo | wc -l)
+    - export MAKEFLAGS=-j$(nproc)
     - $CC --version
     - $CXX --version
     - python --version


### PR DESCRIPTION
This fixes the recent Travis-CI breakage discussed in issue nanopb/nanopb#170.

The fix is to update to newer packages and directly invoke scons.  Seems that upstream has fixed somethings.

The build is now twice as fast thanks to using pre-built `protoc` binary provided by the Github release.