### PR TITLE
Added pb_decode_delimited_noinit

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1017,6 +1017,21 @@ bool checkreturn pb_decode(pb_istream_t *stream, const pb_field_t fields[], void
     return status;
 }
 
+bool pb_decode_delimited_noinit(pb_istream_t *stream, const pb_field_t fields[], void *dest_struct)
+{
+    pb_istream_t substream;
+    bool status;
+
+    if (!pb_make_string_substream(stream, &substream))
+        return false;
+
+    status = pb_decode_noinit(&substream, fields, dest_struct);
+
+    if (!pb_close_string_substream(stream, &substream))
+        return false;
+    return status;
+}
+
 bool pb_decode_delimited(pb_istream_t *stream, const pb_field_t fields[], void *dest_struct)
 {
     pb_istream_t substream;

--- a/pb_decode.h
+++ b/pb_decode.h
@@ -85,6 +85,11 @@ bool pb_decode_noinit(pb_istream_t *stream, const pb_field_t fields[], void *des
  */
 bool pb_decode_delimited(pb_istream_t *stream, const pb_field_t fields[], void *dest_struct);
 
+/* Same as pb_decode_delimited, except that it does not initialize the destination structure.
+ * See pb_decode_noinit
+ */
+bool pb_decode_delimited_noinit(pb_istream_t *stream, const pb_field_t fields[], void *dest_struct);
+
 /* Same as pb_decode, except allows the message to be terminated with a null byte.
  * NOTE: Until nanopb-0.4.0, pb_decode() also allows null-termination. This behaviour
  * is not supported in most other protobuf implementations, so pb_decode_delimited()


### PR DESCRIPTION
This seemed to be missing form the API.
It's simply pb_decode_delimited, but without initializing the target structure. Similar to pb_decode vs pb_decode_noinit.

This is useful for partial updates to an existing data structure, which is how I use it myself.