### PR TITLE
Fix #296 - install path of Python plugins with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(nanopb_BUILD_GENERATOR)
     find_package(PythonInterp 2.7 REQUIRED)
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -c
-            "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
+            "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
No need of specifying the CMAKE_PREFIX_PATH to python when asking for
sysconfig.get_python_lib since everything is installed relative to
CMAKE_PREFIX_PATH anyway.