### PR TITLE
Explicitly handle all enum values in switch

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -351,6 +351,11 @@ static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire
             *size = 4;
             return pb_read(stream, buf, 4);
         
+        case PB_WT_STRING:
+            // Calling read_raw_value with a PB_WT_STRING is an error.
+            // Explicitly handle this case and fallthrough to default to avoid
+            // compiler warnings.
+
         default: PB_RETURN_ERROR(stream, "invalid wire_type");
     }
 }


### PR DESCRIPTION
Building nanopb with clang via Xcode 8.1 fails with [-Werror, -Wswitch-enum]. This PR explicitly handles the missing enum value in the switch statement.

nanopb/pb_decode.c:334:13: error: enumeration value 'PB_WT_STRING' not explicitly handled in switch [-Werror,-Wswitch-enum]
    switch (wire_type)
            ^
1 error generated.