### PR TITLE
Bytes init value fix

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -442,32 +442,32 @@ class Field:
         else:
             return []
 
-    def to_hex_array(self, value):
-        retval = []
+    def to_hex_array(self, default_values):
+        '''Converts a default value bytestring to a list of hex values in string format
+           handles possible octal escapes inserted by protoc'''
+        hex_array = []
         i = 0
-        first = False
-        while i < len(value):
+        while i < len(default_values):
             # Check for escaping
-            if(value[i] == "\\"):
+            if(default_values[i] == "\\"):
                 # If the value is an escaped backslash...
-                if(value[i + 1] == "\\"):
+                if(default_values[i + 1] == "\\"):
                     i = i + 1 # ...Go over one backslash
                 else:
                     # Else, if there's space for octal
-                    if(i + 3 < len(value)):
+                    if(i + 3 < len(default_values)):
                         # Try octal conversion
                         try:
-                            octval = int(value[i + 1: i + 4], 8)
-                            retval.append(str(hex(octval)))
+                            octval = int(default_values[i + 1: i + 4], 8)
+                            hex_array.append(str(hex(octval)))
                             i = i + 4
-                            first = True
                             continue
                         except ValueError:
-                            pass
+                            assert 0, "Invalid default value"
             # In every other case just get the hex value
-            retval.append(str(hex(ord(value[i]))))
+            hex_array.append(str(hex(ord(default_values[i]))))
             i = i + 1
-        return retval
+        return hex_array
 
     def get_initializer(self, null_init, inner_init_only = False):
         '''Return literal expression for this field's default value.

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -57,7 +57,7 @@ if not env.GetOption('clean'):
     if not stdbool or not stdint or not stddef or not string:
         conf.env.Append(CPPDEFINES = {'PB_SYSTEM_HEADER': '\\"pb_syshdr.h\\"'})
         conf.env.Append(CPPPATH = "#../extra")
-	conf.env.Append(SYSHDR = '\\"pb_syshdr.h\\"')
+        conf.env.Append(SYSHDR = '\\"pb_syshdr.h\\"')
         
         if stdbool: conf.env.Append(CPPDEFINES = {'HAVE_STDBOOL_H': 1})
         if stdint: conf.env.Append(CPPDEFINES = {'HAVE_STDINT_H': 1})

--- a/tests/alltypes/alltypes.proto
+++ b/tests/alltypes/alltypes.proto
@@ -100,7 +100,7 @@ message AllTypes {
     optional double     opt_double  = 53 [default = 4053];
     
     optional string     opt_string  = 54 [default = "4054"];
-    optional bytes      opt_bytes   = 55 [default = "4055"];
+    optional bytes      opt_bytes   = 55 [default = "\x34\x5C\x00\xff"];
     optional SubMessage opt_submsg  = 56;
     optional MyEnum     opt_enum    = 57 [default = Second];
     optional EmptyMessage opt_emptymsg = 58;

--- a/tests/alltypes/decode_alltypes.c
+++ b/tests/alltypes/decode_alltypes.c
@@ -135,7 +135,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(strcmp(alltypes.opt_string, "4054") == 0);
         TEST(alltypes.has_opt_bytes     == false);
         TEST(alltypes.opt_bytes.size == 4);
-        TEST(memcmp(alltypes.opt_bytes.bytes, "4055", 4) == 0);
+        TEST(memcmp(alltypes.opt_bytes.bytes, "\x34\x5C\x00\xff", 4) == 0);
         TEST(alltypes.has_opt_submsg    == false);
         TEST(strcmp(alltypes.opt_submsg.substuff1, "1") == 0);
         TEST(alltypes.opt_submsg.substuff2 == 2);

--- a/tests/alltypes_proto3/SConscript
+++ b/tests/alltypes_proto3/SConscript
@@ -8,7 +8,7 @@ if 'PROTOC_VERSION' in env:
     match = re.search('([0-9]+).([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
 
 if match:
-    version = map(int, match.groups())
+    version = list(map(int, match.groups()))
 
 # proto3 syntax is supported by protoc >= 3.0.0
 if env.GetOption('clean') or (match and version[0] >= 3):

--- a/tests/anonymous_oneof/SConscript
+++ b/tests/anonymous_oneof/SConscript
@@ -9,7 +9,7 @@ if 'PROTOC_VERSION' in env:
     match = re.search('([0-9]+).([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
 
 if match:
-    version = map(int, match.groups())
+    version = list(map(int, match.groups()))
 
 # Oneof is supported by protoc >= 2.6.0
 if env.GetOption('clean') or (match and (version[0] > 2 or (version[0] == 2 and version[1] >= 6))):

--- a/tests/field_size_16/alltypes.proto
+++ b/tests/field_size_16/alltypes.proto
@@ -99,7 +99,7 @@ message AllTypes {
     optional double     opt_double  = 10053 [default = 4053];
     
     optional string     opt_string  = 10054 [default = "4054"];
-    optional bytes      opt_bytes   = 10055 [default = "4055"];
+    optional bytes      opt_bytes   = 10055 [default = "\x34\x5C\x00\xff"];
     optional SubMessage opt_submsg  = 10056;
     optional MyEnum     opt_enum    = 10057 [default = Second];
     optional EmptyMessage opt_emptymsg = 10058;

--- a/tests/field_size_16_proto3/SConscript
+++ b/tests/field_size_16_proto3/SConscript
@@ -8,7 +8,7 @@ if 'PROTOC_VERSION' in env:
     match = re.search('([0-9]+).([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
 
 if match:
-    version = map(int, match.groups())
+    version = list(map(int, match.groups()))
 
 # proto3 syntax is supported by protoc >= 3.0.0
 if env.GetOption('clean') or (match and version[0] >= 3):

--- a/tests/field_size_32/alltypes.proto
+++ b/tests/field_size_32/alltypes.proto
@@ -99,7 +99,7 @@ message AllTypes {
     optional double     opt_double  = 10053 [default = 4053];
     
     optional string     opt_string  = 10054 [default = "4054"];
-    optional bytes      opt_bytes   = 10055 [default = "4055"];
+    optional bytes      opt_bytes   = 10055 [default = "\x34\x5C\x00\xff"];
     optional SubMessage opt_submsg  = 10056;
     optional MyEnum     opt_enum    = 10057 [default = Second];
     optional EmptyMessage opt_emptymsg = 10058;

--- a/tests/oneof/SConscript
+++ b/tests/oneof/SConscript
@@ -9,7 +9,7 @@ if 'PROTOC_VERSION' in env:
     match = re.search('([0-9]+).([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
 
 if match:
-    version = map(int, match.groups())
+    version = list(map(int, match.groups()))
 
 # Oneof is supported by protoc >= 2.6.0
 if env.GetOption('clean') or (match and (version[0] > 2 or (version[0] == 2 and version[1] >= 6))):


### PR DESCRIPTION
Fixes init values for byte types. Protoc uses octal format for default values that aren't your typical characters, which was handled incorrectly by nanopb. For example protoc turns "\xff" to "\377" which in turn is encoded character by character by nanopb (taking 4 bytes of space). This was changed in protoc at some point, nanopb 0.3.4 (iirc) worked fine.

There may still be some corner cases that aren't handled properly. Certain special characters and such. More exhaustive test cases would be good to be added.

Also did some minor changes to scons files to add python 3 support (New scons versions run on python 3 as well as 2).

Juha-Pekka Hamina
R&D engineer
Nordic Semiconductor