### PR TITLE
Feature: Flattening nested protobuf names

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -111,7 +111,7 @@ class Names:
     def __add__(self, other):
         if isinstance(other, strtypes):
             return Names(self.parts + (other,))
-        elif isinstance(other, Name):
+        elif isinstance(other, Names):
             return Names(self.parts + other.parts)
         elif isinstance(other, tuple):
             return Names(self.parts + other)
@@ -190,10 +190,13 @@ class Enum:
         self.options = enum_options
         self.names = names
 
+        # by definition, `names` include this enum's name
+        base_name = Names(names.parts[:-1])
+
         if enum_options.long_names:
             self.values = [(names + x.name, x.number) for x in desc.value]
         else:
-            self.values = [(desc.name + x.name, x.number) for x in desc.value]
+            self.values = [(base_name + x.name, x.number) for x in desc.value]
 
         self.value_longnames = [self.names + x.name for x in desc.value]
         self.packed = enum_options.packed_enum

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -95,11 +95,14 @@ try:
 except NameError:
     strtypes = (str, )
 
+
 class Names:
     '''Keeps a set of nested names and formats them to C identifier.'''
     def __init__(self, parts = ()):
         if isinstance(parts, Names):
             parts = parts.parts
+        elif isinstance(parts, strtypes):
+            parts = (parts,)
         self.parts = tuple(parts)
 
     def __str__(self):
@@ -108,6 +111,8 @@ class Names:
     def __add__(self, other):
         if isinstance(other, strtypes):
             return Names(self.parts + (other,))
+        elif isinstance(other, Name):
+            return Names(self.parts + other.parts)
         elif isinstance(other, tuple):
             return Names(self.parts + other)
         else:

--- a/generator/proto/nanopb.proto
+++ b/generator/proto/nanopb.proto
@@ -27,6 +27,12 @@ enum IntSize {
     IS_64 = 64;
 }
 
+enum TypenameMangling {
+    M_NONE = 0; // Default, no typename mangling
+    M_STRIP_PACKAGE = 1; // Strip current package name
+    M_FLATTEN = 2; // Only use last path component
+}
+
 // This is the inner options message, which basically defines options for
 // a field. When it is used in message or file scope, it applies to all
 // fields.
@@ -83,6 +89,9 @@ message NanoPBOptions {
 
   // Generate repeated field with fixed count
   optional bool fixed_count = 16 [default = false];
+
+  // Mangle long names
+  optional TypenameMangling mangle_names = 17 [default = M_NONE];
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options

--- a/tests/typename_mangling/SConscript
+++ b/tests/typename_mangling/SConscript
@@ -1,0 +1,20 @@
+# Test mangle_names option
+
+Import('env')
+
+def set_mangling(type):
+    def command(target, source, env):
+        with open(str(source[0])) as src, open(str(target[0]), "w") as dst:
+            dst.write("* mangle_names:{}\n".format(type))
+            dst.write(src.read())
+    return command
+
+env.Command("strip_package.options", "with_package.options", set_mangling("M_STRIP_PACKAGE"))
+env.Command("strip_package.proto", "with_package.proto", Copy("$TARGET", "$SOURCE"))
+env.NanopbProto(["strip_package", "strip_package.options"])
+env.Program(["test_strip_package.c", "strip_package.pb.c"])
+
+env.Command("flatten.options", "with_package.options", set_mangling("M_FLATTEN"))
+env.Command("flatten.proto", "with_package.proto", Copy("$TARGET", "$SOURCE"))
+env.NanopbProto(["flatten", "flatten.options"])
+env.Program(["test_flatten.c", "flatten.pb.c"])

--- a/tests/typename_mangling/test_flatten.c
+++ b/tests/typename_mangling/test_flatten.c
@@ -1,0 +1,22 @@
+/*
+ * Tests if expected names are generated when M_FLATTEN is used.
+ */
+
+#include <stdio.h>
+#include "unittests.h"
+#include "flatten.pb.h"
+
+int main()
+{
+    TopLevelMessage msg = {0};
+    NestedMessage nmsg = msg.nested;
+    NestedLevel2 nmsg2 = nmsg.nested;
+    NestedLevel3 nmsg3 = nmsg2.nested;
+    nmsg3.nothing = 42;
+
+    msg.short_if_none = ShortIfNone_IfNone_A;
+    msg.short_if_strip_package = ShortIfStripPackage_IfPackage_A;
+    msg.short_if_flatten = IfFlatten_A;
+
+    return nmsg3.nothing; /* this sets `nmsg3` as used, to prevent warning */
+}

--- a/tests/typename_mangling/test_strip_package.c
+++ b/tests/typename_mangling/test_strip_package.c
@@ -1,0 +1,19 @@
+/*
+ * Tests if expected names are generated when M_STRIP_PACKAGE is used.
+ */
+
+#include <stdio.h>
+#include "unittests.h"
+#include "strip_package.pb.h"
+
+int main()
+{
+    TopLevelMessage msg = {0};
+    TopLevelMessage_NestedMessage_NestedLevel2_NestedLevel3 nmsg = msg.nested.nested.nested;
+
+    msg.short_if_none = TopLevelMessage_ShortIfNone_IfNone_A;
+    msg.short_if_strip_package = TopLevelMessage_IfPackage_A;
+    msg.short_if_flatten = TopLevelMessage_ShortIfFlatten_IfFlatten_A;
+
+    return nmsg.nothing; /* marks nmsg as used */
+}

--- a/tests/typename_mangling/with_package.options
+++ b/tests/typename_mangling/with_package.options
@@ -1,0 +1,5 @@
+* long_names:true
+
+com.example.nanopb.TopLevelMessage.ShortIfNone long_names:false
+TopLevelMessage.ShortIfStripPackage long_names:false
+ShortIfFlatten long_names: false

--- a/tests/typename_mangling/with_package.proto
+++ b/tests/typename_mangling/with_package.proto
@@ -1,0 +1,38 @@
+syntax = "proto2";
+
+package com.example.nanopb;
+
+message TopLevelMessage {
+    required uint32 base_field = 1;
+    required NestedMessage nested = 2;
+    optional ShortIfNone short_if_none = 3;
+    optional ShortIfStripPackage short_if_strip_package = 4;
+    optional ShortIfFlatten short_if_flatten = 5;
+
+    message NestedMessage {
+        required NestedLevel2 nested = 1;
+
+        message NestedLevel2 {
+            required NestedLevel3 nested = 1;
+
+            message NestedLevel3 {
+                required uint32 nothing = 1;
+            }
+        }
+    }
+
+    enum ShortIfNone {
+        IfNone_A = 1;
+        IfNone_B = 2;
+    }
+
+    enum ShortIfStripPackage {
+        IfPackage_A = 1;
+        IfPackage_B = 2;
+    }
+
+    enum ShortIfFlatten {
+        IfFlatten_A = 1;
+        IfFlatten_B = 2;
+    }
+}


### PR DESCRIPTION
In our codebase, we use protobuf `package`s and message nesting to organize code. It's great, but it means that in the resulting C code, we would have to deal with _insanely long_ identifiers such as `hw_trezor_messages_bitcoin_TxAck_TransactionType_TxInputType`. In our case, the nesting and organization is useful in other places, but not in the C codebase - it turns out that we can use a flat structure.

This patch introduces a feature that allows us to do two things:

1. strip local package name from type names - useful when you don't have cross-package references
2. strip all but the last component of the type name - useful in cases like ours, when the nested identifiers are unique and you don't need the nesting in C code.

I'm not sure if you're interested in a feature like this, or if this is a good way to implement it. Worth a shot though :)