### PR TITLE
Add --fast option to generator

### DIFF
--- a/pb_common.c
+++ b/pb_common.c
@@ -5,6 +5,7 @@
 
 #include "pb_common.h"
 
+#if PB_ENABLE_SIZE_OPTIMIZED
 bool pb_field_iter_begin(pb_field_iter_t *iter, const pb_field_t *fields, void *dest_struct)
 {
     iter->start = fields;
@@ -94,4 +95,4 @@ bool pb_field_iter_find(pb_field_iter_t *iter, uint32_t tag)
     return false;
 }
 
-
+#endif /* PB_ENABLE_SIZE_OPTIMIZED */

--- a/pb_common.h
+++ b/pb_common.h
@@ -7,6 +7,8 @@
 
 #include "pb.h"
 
+#if PB_ENABLE_SIZE_OPTIMIZED
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,6 +39,8 @@ bool pb_field_iter_find(pb_field_iter_t *iter, uint32_t tag);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
+
+#endif /* PB_ENABLE_SIZE_OPTIMIZED */
 
 #endif
 

--- a/pb_decode.h
+++ b/pb_decode.h
@@ -39,7 +39,7 @@ struct pb_istream_s
 
     void *state; /* Free field for use by callback implementation */
     size_t bytes_left;
-    
+
 #ifndef PB_NO_ERRMSG
     const char *errmsg;
 #endif
@@ -48,7 +48,8 @@ struct pb_istream_s
 /***************************
  * Main decoding functions *
  ***************************/
- 
+
+#if PB_ENABLE_SIZE_OPTIMIZED
 /* Decode a single protocol buffers message from input stream into a C structure.
  * Returns true on success, false on any failure.
  * The actual struct pointed to by dest must match the description in fields.
@@ -59,7 +60,7 @@ struct pb_istream_s
  *    MyMessage msg = {};
  *    uint8_t buffer[64];
  *    pb_istream_t stream;
- *    
+ *
  *    // ... read some data into buffer ...
  *
  *    stream = pb_istream_from_buffer(buffer, count);
@@ -104,6 +105,7 @@ bool pb_decode_nullterminated(pb_istream_t *stream, const pb_field_t fields[], v
  */
 void pb_release(const pb_field_t fields[], void *dest_struct);
 #endif
+#endif /* PB_ENABLE_SIZE_OPTIMIZED */
 
 
 /**************************************


### PR DESCRIPTION
Generate explicit encode/decode options for each protobuf.  When --fast is provided the codegen within those functions is altered so to be optimized for performance.  Rather than using descriptors the codegen explicitly generates code for each type.  This trades off more code size usage for less usage of constants and faster encode/decode.  This can be a more appropriate tradeoff on some embedded platforms (if there's limitations on amount of const usage or performance is more critical
than absolute smallest code footprint).

Without --fast the generated encode/decode functions can still be used and are just fully inlined pass-through wrappers to pb_encode/pb_decode.

Rather than using the generic pb_encode/pb_decode routines, there's new:
- decode_X
- get_encoded_size_X
- encode_X
routines where X is the protobuf message name.  Without --fast these simply redirect to the generic pb_encode/pb_decode routines with 0 overhead (code or performance) assuming a decent inlining compiler.  With --fast these routines are auto-converted to the speed-optimized version which
lets you benchmark before & after really easily.

The has_ fields are also optimized to generate as bitfields rather than individual bytes.  In addition to the speed benefits these changes also:
- reduces stack pressure when putting protobuf structs on the stack
- reduces heap pressure when putting protobuf structs on the heap
- reduces stack pressure because call-depth of speed-optimized encode/decode is much shallower (no recursion)
