### PR TITLE
pb_decode double free error with garbage input, PB_ENABLE_MALLOC and callbacks

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1158,7 +1158,7 @@ static void pb_release_single_field(const pb_field_iter_t *iter)
             ext = ext->next;
         }
     }
-    else if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE)
+    else if (PB_LTYPE(type) == PB_LTYPE_SUBMESSAGE && PB_ATYPE(type) != PB_ATYPE_CALLBACK)
     {
         /* Release fields in submessage or submsg array */
         void *pItem = iter->pData;

--- a/tests/mem_release/mem_release.c
+++ b/tests/mem_release/mem_release.c
@@ -177,9 +177,30 @@ static bool test_OneofMessage()
     return true;
 }
 
+/* Garbage input */
+static bool test_Garbage()
+{
+    const uint8_t buffer[] = "I'm only happy when it rains";
+    const size_t msgsize = sizeof(buffer);
+
+    {
+        OneofMessage msg = OneofMessage_init_zero;
+        pb_istream_t stream = pb_istream_from_buffer(buffer, msgsize);
+        TEST(!pb_decode(&stream, OneofMessage_fields, &msg));
+    }
+
+    {
+        TestMessage msg = TestMessage_init_zero;
+        pb_istream_t stream = pb_istream_from_buffer(buffer, msgsize);
+        TEST(!pb_decode(&stream, TestMessage_fields, &msg));
+    }
+
+    return true;
+}
+
 int main()
 {
-    if (test_TestMessage() && test_OneofMessage())
+    if (test_TestMessage() && test_OneofMessage() && test_Garbage())
         return 0;
     else
         return 1;

--- a/tests/mem_release/mem_release.c
+++ b/tests/mem_release/mem_release.c
@@ -177,6 +177,11 @@ static bool test_OneofMessage()
     return true;
 }
 
+static bool dummy_decode_cb(pb_istream_t *stream, const pb_field_t *field, void **arg)
+{
+    return false;
+}
+
 /* Garbage input */
 static bool test_Garbage()
 {
@@ -193,6 +198,14 @@ static bool test_Garbage()
         TestMessage msg = TestMessage_init_zero;
         pb_istream_t stream = pb_istream_from_buffer(buffer, msgsize);
         TEST(!pb_decode(&stream, TestMessage_fields, &msg));
+    }
+
+    {
+        RepeatedMessage msg = RepeatedMessage_init_zero;
+        pb_istream_t stream = pb_istream_from_buffer(buffer, msgsize);
+        msg.subs.arg = NULL;
+        msg.subs.funcs.decode = dummy_decode_cb;
+        TEST(!pb_decode(&stream, RepeatedMessage_fields, &msg));
     }
 
     return true;

--- a/tests/mem_release/mem_release.proto
+++ b/tests/mem_release/mem_release.proto
@@ -33,3 +33,9 @@ message OneofMessage
     }
     required int32 last = 4;
 }
+
+message RepeatedMessage
+{
+    required int32 first = 1;
+    repeated SubMessage subs = 2;
+}


### PR DESCRIPTION
Hello. We've encoutered a bug and this PR contains a failing test demonstrating the issue:

If decode callbacks are used together with ([untrusted](http://jpa.kapsi.fi/nanopb/docs/security.html#division-of-trusted-and-untrusted-data)) garbage data and PB_ENABLE_MALLOC, a double-free occurs somewhere inside `pb_release`, called from `pb_decode` causing a segmentation fault.

This does not happen without PB_ENABLE_MALLOC or without decode callbacks (the test in the first commit of this PR passes)

`scons` output (tested on Debian Jessie)
```
... snip ...
[ OK ]   All patterns found in build/inline/inline.pb.h
run_test(["build/mem_release/mem_release.output"], ["build/mem_release/mem_release"])
Command line: ['build/mem_release/mem_release']
mem_release: build/common/malloc_wrappers.c:45: counting_free: Assertion `alloc_count > 0' failed.
[FAIL]   Program build/mem_release/mem_release returned -6
scons: *** [build/mem_release/mem_release.output] Error -6
scons: building terminated because of errors.
```

Thanks for taking a look!