### PR TITLE
Made some changes for Error Output.

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -44,6 +44,9 @@ except TypeError:
          *** which protoc                                                         ***
          *** protoc --version                                                     ***
          *** python -c 'import google.protobuf; print(google.protobuf.__file__)'  ***
+         *** If you are not able to find the python protobuf version using the    ***
+         *** above command, use this command.                                     ***
+         *** pip freeze | grep -i protobuf                                        ***
          ****************************************************************************
     ''' + '\n')
     raise


### PR DESCRIPTION
Sometimes python protobuf version can't be found out by the above listed command. So added one more command to find python protobuf version which utilises pip freeze command.