### PR TITLE
cmake: Include CMAKE_INSTALL_LIBDIR in CMAKE_INSTALL_CMAKEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(MSVC AND nanopb_MSVC_STATIC_RUNTIME)
 endif()
 
 if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
-    set(CMAKE_INSTALL_CMAKEDIR "lib/cmake/nanopb")
+    set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/nanopb")
 endif()
 
 if(nanopb_BUILD_GENERATOR)


### PR DESCRIPTION
If user defines non-standard directory in CMAKE_INSTALL_LIBDIR
option (i.e. /usr/lib64), then CMAKE_INSTALL_CMAKEDIR should
use it as a prefix.