### PR TITLE
Correction of WIN32 flag in generator function

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -149,7 +149,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
   set(GENERATOR_PATH ${CMAKE_BINARY_DIR}/nanopb/generator)
 
   set(NANOPB_GENERATOR_EXECUTABLE ${GENERATOR_PATH}/nanopb_generator.py)
-  if (WIN32)
+  if (CMAKE_HOST_WIN32)
     set(NANOPB_GENERATOR_PLUGIN ${GENERATOR_PATH}/protoc-gen-nanopb.bat)
   else()
     set(NANOPB_GENERATOR_PLUGIN ${GENERATOR_PATH}/protoc-gen-nanopb)


### PR DESCRIPTION
Previously used flag (WIN32) indicated target system on which compiler
was running. Proposed change (CMAKE_HOST_WIN32) will indicate if host
system is windows.

This allows to cross compile for windows on linux machine or cross
compile for linux on windows machine. Also this change won't affect
builds for native linux or native windows.