### PR TITLE
Fix Win32 shared lib build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,10 @@ endif()
 
 if(nanopb_BUILD_RUNTIME)
     if(BUILD_SHARED_LIBS)
+        if(MSVC)
+            set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+        endif()
+        
         add_library(protobuf-nanopb SHARED
             pb.h
             pb_common.h
@@ -79,7 +83,9 @@ if(nanopb_BUILD_RUNTIME)
             SOVERSION ${nanopb_SOVERSION})
         install(TARGETS protobuf-nanopb EXPORT nanopb-targets
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
         target_include_directories(protobuf-nanopb INTERFACE
           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )


### PR DESCRIPTION
Hi! I created a port for `nanopb` in `vcpkg` one month ago: https://github.com/Microsoft/vcpkg/pull/5057

I found there are two problems with the shared lib build support on Win32 with MSVC:

1. The generated DLL file exports no symbols, so a corresponding export lib will not be created. And the user of this lib has nothing to link to.

    In MSVC, functions may be exported from a DLL by two ways:

    1. [Exporting from a DLL Using __declspec(dllexport)](https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-declspec-dllexport?view=vs-2017).

        oniguruma is an example: https://github.com/winlibs/oniguruma/blob/master/src/oniguruma.h#L58-L60

    2. [Exporting from a DLL Using DEF Files](https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-def-files?view=vs-2017)

       Since we use CMake here, I think we can set [```CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS```](https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html) to `ON`: 
       >Enable this boolean property to automatically create a module definition (.def) file with all global symbols found in the input .obj files for a SHARED library (or executable with ENABLE_EXPORTS) on Windows. The module definition file will be passed to the linker causing all symbols to be exported from the .dll. For global data symbols, __declspec(dllimport) must still be used when compiling against the code in the .dll. All other function symbols will be automatically exported and imported by callers. This simplifies porting projects to Windows by reducing the need for explicit dllexport markup, even in C++ classes.

2. The generated DLL file installed to a wrong path.

    It is similar to: https://stackoverflow.com/questions/22278381/cmake-add-library-followed-by-install-library-destination