### PR TITLE
🔀 use min/max enum value for min/max

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -245,9 +245,12 @@ class Enum:
 
         result += ' %s;' % self.names
 
-        result += '\n#define _%s_MIN %s' % (self.names, self.values[0][0])
-        result += '\n#define _%s_MAX %s' % (self.names, self.values[-1][0])
-        result += '\n#define _%s_ARRAYSIZE ((%s)(%s+1))' % (self.names, self.names, self.values[-1][0])
+        # sort the enum by value
+        sorted_values = sorted(self.values, key = lambda x: (x[1], x[0]))
+
+        result += '\n#define _%s_MIN %s' % (self.names, sorted_values[0][0])
+        result += '\n#define _%s_MAX %s' % (self.names, sorted_values[-1][0])
+        result += '\n#define _%s_ARRAYSIZE ((%s)(%s+1))' % (self.names, self.names, sorted_values[-1][0])
 
         if not self.options.long_names:
             # Define the long names always so that enum value references

--- a/tests/enum_minmax/SConscript
+++ b/tests/enum_minmax/SConscript
@@ -1,0 +1,8 @@
+# Test that different sizes of enum fields are properly encoded and decoded.
+
+Import('env')
+
+env.NanopbProto('enumminmax')
+
+p = env.Program(["enumminmax_unittests.c",])
+env.RunTest(p)

--- a/tests/enum_minmax/enumminmax.proto
+++ b/tests/enum_minmax/enumminmax.proto
@@ -1,0 +1,22 @@
+/* Test out-of-order enum values.
+ */
+
+syntax = "proto3";
+
+enum Language {
+    UNKNOWN = 0;
+    ENGLISH_EN_GB = 12;
+    ENGLISH_EN_US = 1;
+    FRENCH_FR_FR = 2;
+    ITALIAN_IT_IT = 3;
+    GERMAN_DE_DE = 4;
+    SPANISH_ES_AR = 13;
+    SPANISH_ES_ES = 5;
+    SPANISH_ES_MX = 14;
+    SWEDISH_SV_SE = 6;
+    DUTCH_NL_NL = 7;
+    KOREAN_KO_KR = 8;
+    JAPANESE_JA_JP = 9;
+    CHINESE_SIMPLIFIED_ZH_CN = 10;
+    CHINESE_TRADITIONAL_ZH_TW = 11;
+}

--- a/tests/enum_minmax/enumminmax_unittests.c
+++ b/tests/enum_minmax/enumminmax_unittests.c
@@ -1,0 +1,16 @@
+#include "unittests.h"
+#include "enumminmax.pb.h"
+
+int main()
+{
+    int status = 0;
+
+    COMMENT("Verify min/max on unsorted enum");
+    {
+        TEST(_Language_MIN == Language_UNKNOWN);
+        TEST(_Language_MAX == Language_SPANISH_ES_MX);
+        TEST(_Language_ARRAYSIZE == (Language_SPANISH_ES_MX+1));
+    }
+
+    return status;
+}


### PR DESCRIPTION
Unsorted enums in message specifications do not result in correct
min/max values per the protobuf spec for cpp code:
https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum

The google cpp compiler uses the min/max _value_ in the message spec, so
this patch updates nanopb to do the same.

Example input:

```protobuf
syntax = "proto3";

enum Language {
    UNKNOWN = 0;
    ENGLISH_EN_GB = 12;
    ENGLISH_EN_US = 1;
    FRENCH_FR_FR = 2;
    ITALIAN_IT_IT = 3;
    GERMAN_DE_DE = 4;
    SPANISH_ES_AR = 13;
    SPANISH_ES_ES = 5;
    SPANISH_ES_MX = 14;
    SWEDISH_SV_SE = 6;
    DUTCH_NL_NL = 7;
    KOREAN_KO_KR = 8;
    JAPANESE_JA_JP = 9;
    CHINESE_SIMPLIFIED_ZH_CN = 10;
    CHINESE_TRADITIONAL_ZH_TW = 11;
}
```

This would previously result in:
```c
 #define _Language_MIN Language_UNKNOWN
 #define _Language_MAX Language_CHINESE_TRADITIONAL_ZH_TW
 #define _Language_ARRAYSIZE ((Language)(Language_CHINESE_TRADITIONAL_ZH_TW+1))
```

After this patch,
```c
 #define _Language_MIN Language_UNKNOWN
 #define _Language_MAX Language_SPANISH_ES_MX
 #define _Language_ARRAYSIZE ((Language)(Language_SPANISH_ES_MX+1))
```

Add a test `enum_minmax` to cover this case.