### PR TITLE
plugin include paths in cmake fix

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -216,7 +216,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
     set(NANOPB_OPTIONS_DIRS)
 
     # If there an options file in the same working directory, set it as a dependency
-    set(NANOPB_OPTIONS_FILE ${FIL_DIR}/${FIL_WE}.options)
+    set(NANOPB_OPTIONS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FIL_DIR}/${FIL_WE}.options)
     if(EXISTS ${NANOPB_OPTIONS_FILE})
         # Get directory as lookups for dependency options fail if an options
         # file is used. The options is still set as a dependency of the


### PR DESCRIPTION
The cmake support checks *.options files and adds plugin include option "-I" so the plugin can find it.
Currently the path is relative and cmake will assume it is relative to CMAKE_CURRENT_BINARY_DIR. Since this is source file it should be relative to CMAKE_CURRENT_SOURCE_DIR. 
I guess it will work if you build in the source dir but not in general case.
This will fix #116 if you use cmake.