### PR TITLE
Introduce new compile time flag: PB_ENCODE_ARRAYS_UNPACKED

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -55,6 +55,10 @@ PB_SYSTEM_HEADER               Replace the standard header files with a single
                                for example *#define PB_SYSTEM_HEADER "foo.h"*.
 PB_WITHOUT_64BIT               Disable 64-bit support, for old compilers or
                                for a slight speedup on 8-bit platforms.
+PB_ENCODE_ARRAYS_UNPACKED      Don't encode scalar arrays as packed.
+                               This is only to be used when the decoder on the
+                               receiving side cannot process packed scalar
+                               arrays. Such example is older protobuf.js.
 ============================  ================================================
 
 The PB_MAX_REQUIRED_FIELDS, PB_FIELD_16BIT and PB_FIELD_32BIT settings allow

--- a/pb.h
+++ b/pb.h
@@ -40,6 +40,11 @@
  * to do so through the descriptorsize option in .options file. */
 /* #define PB_FIELDINFO_WIDTH 4 */
 
+/* Don't encode scalar arrays as packed. This is only to be used when
+ * the decoder on the receiving side cannot process packed scalar arrays.
+ * Such example is older protobuf.js. */
+/* #define PB_ENCODE_ARRAYS_UNPACKED 1 */
+
 /******************************************************************
  * You usually don't need to change anything below this line.     *
  * Feel free to look around and use the defined macros, though.   *

--- a/pb_encode.c
+++ b/pb_encode.c
@@ -117,6 +117,7 @@ static bool checkreturn encode_array(pb_ostream_t *stream, pb_field_iter_t *fiel
     if (PB_ATYPE(field->type) != PB_ATYPE_POINTER && count > field->array_size)
         PB_RETURN_ERROR(stream, "array max size exceeded");
     
+#ifndef PB_ENCODE_ARRAYS_UNPACKED
     /* We always pack arrays if the datatype allows it. */
     if (PB_LTYPE(field->type) <= PB_LTYPE_LAST_PACKABLE)
     {
@@ -170,6 +171,7 @@ static bool checkreturn encode_array(pb_ostream_t *stream, pb_field_iter_t *fiel
         }
     }
     else /* Unpacked fields */
+#endif
     {
         for (i = 0; i < count; i++)
         {


### PR DESCRIPTION
Don't encode scalar arrays as packed. This is only to be used when
the decoder on the receiving side cannot process packed scalar arrays.
Such example is older protobuf.js.

Fixes https://github.com/nanopb/nanopb/issues/426