### PR TITLE
Fix "unused variable" warning when using PB_ENCODE_ARRAYS_UNPACKED

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -124,7 +124,9 @@ static bool checkreturn encode_array(pb_ostream_t *stream, pb_field_iter_t *fiel
 {
     pb_size_t i;
     pb_size_t count;
+#ifndef PB_ENCODE_ARRAYS_UNPACKED
     size_t size;
+#endif
 
     count = *(pb_size_t*)field->pSize;
 


### PR DESCRIPTION
In the last PR I forgot to add this change. Otherwise, the build fails with `-Werror` because `-Wunused-variable` is emitted when PB_ENCODE_ARRAYS_UNPACKED is used.

This should be backported into `maintenance_0.3` branch as well.