### PR TITLE
Switch to using Python 3 for code generation, as Python 2.7 is EOL

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # kate: replace-tabs on; indent-width 4;
 
 from __future__ import unicode_literals


### PR DESCRIPTION
Nanopb is currently still using Python2 via `nanopb_generator.py`. This PR changes the shebang to look for python3 in the environment, just in time for Python2 to reach end-of-life.