### PR TITLE
Allow comma-separated option parsing to handle "#include" in options

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1855,6 +1855,7 @@ def main_plugin():
         lex = shlex.shlex(params)
         lex.whitespace_split = True
         lex.whitespace = ','
+        lex.commenters = ''
         args = list(lex)
 
     optparser.usage = "Usage: protoc --nanopb_out=[options][,more_options]:outdir file.proto"


### PR DESCRIPTION
When calling `protoc --plugin=protoc-gen-nanopb=protoc-gen-nanopb-plugin --nanopb_out=. '--nanopb_opt=--library-include-format=#include"%s"' --nanopb_opt=--no-strip-path --nanopb_opt=-xgenerator/nanopb/options.proto`, The following is given to `nanopb_generator.py` as `params`:

```--library-include-format=#include"%s"',--no-strip-path,--nanopb_opt=-xgenerator/nanopb/options.proto```

This passes the `len(args) == 1 and ',' in args[0]` check, so it then gets lexed. However, since there's a `#` character, `shlex` discards everything but: `--library-include-format=`.

Setting `lex.commenters = ''` allows `--library-include-format` to be specified in the above manner.