### PR TITLE
Change proto3 message types to be optional

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -349,7 +349,10 @@ class Field:
                   self.rules = 'FIXARRAY'
 
         elif field_options.proto3:
-            self.rules = 'SINGULAR'
+            if desc.type == FieldD.TYPE_MESSAGE:
+                self.rules = 'OPTIONAL'
+            else:
+                self.rules = 'SINGULAR'
         elif desc.label == FieldD.LABEL_REQUIRED:
             self.rules = 'REQUIRED'
         elif desc.label == FieldD.LABEL_OPTIONAL:

--- a/tests/alltypes_proto3/decode_alltypes.c
+++ b/tests/alltypes_proto3/decode_alltypes.c
@@ -20,13 +20,13 @@
 bool check_alltypes(pb_istream_t *stream, int mode)
 {
     AllTypes alltypes = AllTypes_init_zero;
-    
+
     /* Fill with garbage to better detect initialization errors */
     memset(&alltypes, 0xAA, sizeof(alltypes));
-    
+
     if (!pb_decode(stream, AllTypes_fields, &alltypes))
         return false;
-    
+
     TEST(alltypes.rep_int32_count == 5 && alltypes.rep_int32[4] == -2001 && alltypes.rep_int32[0] == 0);
     TEST(alltypes.rep_int64_count == 5 && alltypes.rep_int64[4] == -2002 && alltypes.rep_int64[0] == 0);
     TEST(alltypes.rep_uint32_count == 5 && alltypes.rep_uint32[4] == 2003 && alltypes.rep_uint32[0] == 0);
@@ -34,15 +34,15 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(alltypes.rep_sint32_count == 5 && alltypes.rep_sint32[4] == -2005 && alltypes.rep_sint32[0] == 0);
     TEST(alltypes.rep_sint64_count == 5 && alltypes.rep_sint64[4] == -2006 && alltypes.rep_sint64[0] == 0);
     TEST(alltypes.rep_bool_count == 5 && alltypes.rep_bool[4] == true && alltypes.rep_bool[0] == false);
-    
+
     TEST(alltypes.rep_fixed32_count == 5 && alltypes.rep_fixed32[4] == 2008 && alltypes.rep_fixed32[0] == 0);
     TEST(alltypes.rep_sfixed32_count == 5 && alltypes.rep_sfixed32[4] == -2009 && alltypes.rep_sfixed32[0] == 0);
     TEST(alltypes.rep_float_count == 5 && alltypes.rep_float[4] == 2010.0f && alltypes.rep_float[0] == 0.0f);
-    
+
     TEST(alltypes.rep_fixed64_count == 5 && alltypes.rep_fixed64[4] == 2011 && alltypes.rep_fixed64[0] == 0);
     TEST(alltypes.rep_sfixed64_count == 5 && alltypes.rep_sfixed64[4] == -2012 && alltypes.rep_sfixed64[0] == 0);
     TEST(alltypes.rep_double_count == 5 && alltypes.rep_double[4] == 2013.0 && alltypes.rep_double[0] == 0.0);
-    
+
     TEST(alltypes.rep_string_count == 5 && strcmp(alltypes.rep_string[4], "2014") == 0 && alltypes.rep_string[0][0] == '\0');
     TEST(alltypes.rep_bytes_count == 5 && alltypes.rep_bytes[4].size == 4 && alltypes.rep_bytes[0].size == 0);
     TEST(memcmp(alltypes.rep_bytes[4].bytes, "2015", 4) == 0);
@@ -51,14 +51,14 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(strcmp(alltypes.rep_submsg[4].substuff1, "2016") == 0 && alltypes.rep_submsg[0].substuff1[0] == '\0');
     TEST(alltypes.rep_submsg[4].substuff2 == 2016 && alltypes.rep_submsg[0].substuff2 == 0);
     TEST(alltypes.rep_submsg[4].substuff3 == 2016 && alltypes.rep_submsg[0].substuff3 == 0);
-    
+
     TEST(alltypes.rep_enum_count == 5 && alltypes.rep_enum[4] == MyEnum_Truth && alltypes.rep_enum[0] == MyEnum_Zero);
     TEST(alltypes.rep_emptymsg_count == 5);
-    
+
     TEST(alltypes.rep_fbytes_count == 5);
     TEST(alltypes.rep_fbytes[0][0] == 0 && alltypes.rep_fbytes[0][3] == 0);
     TEST(memcmp(alltypes.rep_fbytes[4], "2019", 4) == 0);
-    
+
     if (mode == 0)
     {
         /* Expect default values */
@@ -69,17 +69,18 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(alltypes.sng_sint32        == 0);
         TEST(alltypes.sng_sint64        == 0);
         TEST(alltypes.sng_bool          == false);
-        
+
         TEST(alltypes.sng_fixed32       == 0);
         TEST(alltypes.sng_sfixed32      == 0);
         TEST(alltypes.sng_float         == 0.0f);
-        
+
         TEST(alltypes.sng_fixed64       == 0);
         TEST(alltypes.sng_sfixed64      == 0);
         TEST(alltypes.sng_double        == 0.0);
-        
+
         TEST(strcmp(alltypes.sng_string, "") == 0);
         TEST(alltypes.sng_bytes.size == 0);
+        TEST(alltypes.has_sng_submsg == false);
         TEST(strcmp(alltypes.sng_submsg.substuff1, "") == 0);
         TEST(alltypes.sng_submsg.substuff2 == 0);
         TEST(alltypes.sng_submsg.substuff3 == 0);
@@ -101,18 +102,19 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(alltypes.sng_sint32        == 3045);
         TEST(alltypes.sng_sint64        == 3046);
         TEST(alltypes.sng_bool          == true);
-        
+
         TEST(alltypes.sng_fixed32       == 3048);
         TEST(alltypes.sng_sfixed32      == 3049);
         TEST(alltypes.sng_float         == 3050.0f);
-        
+
         TEST(alltypes.sng_fixed64       == 3051);
         TEST(alltypes.sng_sfixed64      == 3052);
         TEST(alltypes.sng_double        == 3053.0);
-        
+
         TEST(strcmp(alltypes.sng_string, "3054") == 0);
         TEST(alltypes.sng_bytes.size == 4);
         TEST(memcmp(alltypes.sng_bytes.bytes, "3055", 4) == 0);
+        TEST(alltypes.has_sng_submsg == true);
         TEST(strcmp(alltypes.sng_submsg.substuff1, "3056") == 0);
         TEST(alltypes.sng_submsg.substuff2 == 3056);
         TEST(alltypes.sng_submsg.substuff3 == 0);
@@ -123,7 +125,7 @@ bool check_alltypes(pb_istream_t *stream, int mode)
         TEST(strcmp(alltypes.oneof.oneof_msg1.substuff1, "4059") == 0);
         TEST(alltypes.oneof.oneof_msg1.substuff2 == 4059);
     }
-    
+
     TEST(alltypes.req_limits.int32_min  == INT32_MIN);
     TEST(alltypes.req_limits.int32_max  == INT32_MAX);
     TEST(alltypes.req_limits.uint32_min == 0);
@@ -134,9 +136,9 @@ bool check_alltypes(pb_istream_t *stream, int mode)
     TEST(alltypes.req_limits.uint64_max == UINT64_MAX);
     TEST(alltypes.req_limits.enum_min   == HugeEnum_Negative);
     TEST(alltypes.req_limits.enum_max   == HugeEnum_Positive);
-    
+
     TEST(alltypes.end == 1099);
-    
+
     return true;
 }
 
@@ -148,14 +150,14 @@ int main(int argc, char **argv)
 
     /* Whether to expect the optional values or the default values. */
     int mode = (argc > 1) ? atoi(argv[1]) : 0;
-    
+
     /* Read the data into buffer */
     SET_BINARY_MODE(stdin);
     count = fread(buffer, 1, sizeof(buffer), stdin);
-    
+
     /* Construct a pb_istream_t for reading from the buffer */
     stream = pb_istream_from_buffer(buffer, count);
-    
+
     /* Decode and print out the stuff */
     if (!check_alltypes(&stream, mode))
     {

--- a/tests/alltypes_proto3/encode_alltypes.c
+++ b/tests/alltypes_proto3/encode_alltypes.c
@@ -11,10 +11,10 @@
 int main(int argc, char **argv)
 {
     int mode = (argc > 1) ? atoi(argv[1]) : 0;
-    
+
     /* Initialize the structure with constants */
     AllTypes alltypes = AllTypes_init_zero;
-    
+
     alltypes.rep_int32_count = 5; alltypes.rep_int32[4] = -2001;
     alltypes.rep_int64_count = 5; alltypes.rep_int64[4] = -2002;
     alltypes.rep_uint32_count = 5; alltypes.rep_uint32[4] = 2003;
@@ -22,15 +22,15 @@ int main(int argc, char **argv)
     alltypes.rep_sint32_count = 5; alltypes.rep_sint32[4] = -2005;
     alltypes.rep_sint64_count = 5; alltypes.rep_sint64[4] = -2006;
     alltypes.rep_bool_count = 5; alltypes.rep_bool[4] = true;
-    
+
     alltypes.rep_fixed32_count = 5; alltypes.rep_fixed32[4] = 2008;
     alltypes.rep_sfixed32_count = 5; alltypes.rep_sfixed32[4] = -2009;
     alltypes.rep_float_count = 5; alltypes.rep_float[4] = 2010.0f;
-    
+
     alltypes.rep_fixed64_count = 5; alltypes.rep_fixed64[4] = 2011;
     alltypes.rep_sfixed64_count = 5; alltypes.rep_sfixed64[4] = -2012;
     alltypes.rep_double_count = 5; alltypes.rep_double[4] = 2013.0;
-    
+
     alltypes.rep_string_count = 5; strcpy(alltypes.rep_string[4], "2014");
     alltypes.rep_bytes_count = 5; alltypes.rep_bytes[4].size = 4;
     memcpy(alltypes.rep_bytes[4].bytes, "2015", 4);
@@ -39,13 +39,13 @@ int main(int argc, char **argv)
     strcpy(alltypes.rep_submsg[4].substuff1, "2016");
     alltypes.rep_submsg[4].substuff2 = 2016;
     alltypes.rep_submsg[4].substuff3 = 2016;
-    
+
     alltypes.rep_enum_count = 5; alltypes.rep_enum[4] = MyEnum_Truth;
     alltypes.rep_emptymsg_count = 5;
-    
+
     alltypes.rep_fbytes_count = 5;
     memcpy(alltypes.rep_fbytes[4], "2019", 4);
-    
+
     alltypes.req_limits.int32_min  = INT32_MIN;
     alltypes.req_limits.int32_max  = INT32_MAX;
     alltypes.req_limits.uint32_min = 0;
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     alltypes.req_limits.uint64_max = UINT64_MAX;
     alltypes.req_limits.enum_min   = HugeEnum_Negative;
     alltypes.req_limits.enum_max   = HugeEnum_Positive;
-    
+
     if (mode != 0)
     {
         /* Fill in values for singular fields */
@@ -67,18 +67,19 @@ int main(int argc, char **argv)
         alltypes.sng_sint32        = 3045;
         alltypes.sng_sint64        = 3046;
         alltypes.sng_bool          = true;
-        
+
         alltypes.sng_fixed32       = 3048;
         alltypes.sng_sfixed32      = 3049;
         alltypes.sng_float         = 3050.0f;
-        
+
         alltypes.sng_fixed64       = 3051;
         alltypes.sng_sfixed64      = 3052;
         alltypes.sng_double        = 3053.0;
-        
+
         strcpy(alltypes.sng_string, "3054");
         alltypes.sng_bytes.size = 4;
         memcpy(alltypes.sng_bytes.bytes, "3055", 4);
+        alltypes.has_sng_submsg = true;
         strcpy(alltypes.sng_submsg.substuff1, "3056");
         alltypes.sng_submsg.substuff2 = 3056;
         alltypes.sng_enum = MyEnum_Truth;
@@ -88,13 +89,13 @@ int main(int argc, char **argv)
         strcpy(alltypes.oneof.oneof_msg1.substuff1, "4059");
         alltypes.oneof.oneof_msg1.substuff2 = 4059;
     }
-    
+
     alltypes.end = 1099;
-    
+
     {
         uint8_t buffer[AllTypes_size];
         pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
-        
+
         /* Now encode it and check if we succeeded. */
         if (pb_encode(&stream, AllTypes_fields, &alltypes))
         {


### PR DESCRIPTION
Message types can be used as wrappers (e.g. [wrappers.proto](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/wrappers.proto)) to encode "nullable" types. For proto3, the current generated messages does not add the "`has_`" fields to indicate this, so I've changed it as such :)