### PR TITLE
Nanopb Generator as a python package

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -54,6 +54,9 @@ except TypeError:
          ****************************************************************************
     ''' + '\n')
     raise
+except ImportError:
+    # Invoked directly instead of via installed scripts.
+    import proto.nanopb_pb2 as nanopb_pb2
 except:
     sys.stderr.write('''
          ********************************************************************

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -54,8 +54,8 @@ except TypeError:
          ****************************************************************************
     ''' + '\n')
     raise
-except ImportError:
-    # Invoked directly instead of via installed scripts.
+except (ValueError, SystemError):
+    # Probably invoked directly instead of via installed scripts.
     import proto.nanopb_pb2 as nanopb_pb2
 except:
     sys.stderr.write('''

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -36,7 +36,7 @@ except:
     raise
 
 try:
-    import proto.nanopb_pb2 as nanopb_pb2
+    from .proto import nanopb_pb2
 except TypeError:
     sys.stderr.write('''
          ****************************************************************************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "nanopb"
+version = "0.3.9.4"
+description = "Nanopb is a small code-size Protocol Buffers implementation in ansi C. It is especially suitable for use in microcontrollers, but fits any memory restricted system."
+authors = ["Petteri Aimonen"]
+license = "Zlib"
+packages = [
+    {include = "generator"}
+]
+
+[tool.poetry.scripts]
+nanopb_generator = "generator.nanopb_generator:main_cli"
+protoc-gen-nanopb = "generator.nanopb_generator:main_plugin"
+[tool.poetry.dependencies]
+python = ">=2.7"
+protobuf = "^3.11"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ nanopb_generator = "generator.nanopb_generator:main_cli"
 protoc-gen-nanopb = "generator.nanopb_generator:main_plugin"
 [tool.poetry.dependencies]
 python = ">=2.7"
-protobuf = "<=3.6"
+protobuf = ">=3.6"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,10 @@ version = "0.3.9.4"
 description = "Nanopb is a small code-size Protocol Buffers implementation in ansi C. It is especially suitable for use in microcontrollers, but fits any memory restricted system."
 authors = ["Petteri Aimonen"]
 license = "Zlib"
-packages = [
-    {include = "generator"}
-]
 
 [tool.poetry.scripts]
-nanopb_generator = "generator.nanopb_generator:main_cli"
-protoc-gen-nanopb = "generator.nanopb_generator:main_plugin"
+nanopb_generator = "nanopb.generator.nanopb_generator:main_cli"
+protoc-gen-nanopb = "nanopb.generator.nanopb_generator:main_plugin"
 [tool.poetry.dependencies]
 python = ">=2.7"
 protobuf = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ nanopb_generator = "generator.nanopb_generator:main_cli"
 protoc-gen-nanopb = "generator.nanopb_generator:main_plugin"
 [tool.poetry.dependencies]
 python = ">=2.7"
-protobuf = "^3.11"
+protobuf = "<=3.6"
 
 [tool.poetry.dev-dependencies]
 

--- a/tools/set_version.sh
+++ b/tools/set_version.sh
@@ -14,3 +14,4 @@ then sed -i -e 's/"version":\s*"[^"]*"/"version": "'$VERSION_ONLY'"/' library.js
 fi
 
 sed -i -e 's/\s*version =.*/version = "'$VERSION_ONLY'"/' conanfile.py
+sed -i -e 's/\s*version =.*/version = "'$VERSION_ONLY'"/' pyproject.toml


### PR DESCRIPTION
This Pull request allows nanopb's generator to be built into a python package.


#   What functionality it fixes/adds.
### additions
- Adds `poetry` as a development dependency, to build wheels from the `generator` folder.
- `pyproject.toml` project configuration file - describes the package as a whole and how to build it. (sdist)
- `nanopb_generator` script path, allows `generator/nanopb_generator` to be invoked from the CLI from any directory.
```
root@0a250617787d:~# ls
root@0a250617787d:~# nanopb_generator
Usage: nanopb_generator.py [options] file.pb ...

Options:
  -h, --help            show this help message and exit
  -x FILE               Exclude file from generated #include list.
# output truncated for brevity
```
- `protoc-gen-nanopb` script path, allows `protoc` to automatically detect the nanopb plugin. this means the plugin doesn't need to be explicitly declared!
```
root@0a250617787d:~# ls
empty.proto
root@0a250617787d:~# protoc --nanopb_out=. empty.proto
root@0a250617787d:~# ls
empty.pb.c  empty.pb.h  empty.proto
root@0a250617787d:~# cat empty.pb.c
/* Automatically generated nanopb constant definitions */
/* Generated by nanopb-0.4.0-dev */

#include "empty.pb.h"

/* @@protoc_insertion_point(includes) */
#if PB_PROTO_HEADER_VERSION != 40
#error Regenerate this file with the current version of nanopb generator.
#endif

PB_BIND(rover_empty_Empty, rover_empty_Empty, AUTO)



/* @@protoc_insertion_point(eof) */
```
## building the wheel
```
>  poetry build
Building nanopb (0.3.9.4)
 - Building sdist
 - Built nanopb-0.3.9.4.tar.gz

 - Building wheel
 - Built nanopb-0.3.9.4-py2.py3-none-any.whl
```
### fixes
`generator/nanopb_generator.py`
 - adjusted to use a relative import from its package, to make it work with python packaging.
#    How can the problem be reproduced / when would the feature be useful.
This PR allows nanopb, when installed as a python package. to be transparent to the end-user when generating sources.

I, for one, found automating NanoPB in my downstream build process to be somewhat frustrating, due to the requirement of embedding nanopb's git repository / binary distributions. Having an install-able python wheel allows downstream users to avoid this. 

This PR also allows nanopb's generators to target python3 as a side-effect, without effecting the shebang line (see #441 )



## Problems
For this pull request I took a minimalistic approach, only changing the bare-minimum to achieve the feature. 
Presently, the Nanopb generators get installed into the `generators` package, preferably I would like to place things under `nanopb.generators`. Unfortunately It would appear that we would need to move the `/generators/` folder to `/nanopb/generators` to achieve that result.

Oh, and please do review the `pyproject.toml` and make sure I got the author information correct.

---------

Closes: #401 
Relates to: #441 