### PR TITLE
Fix fieldlist macro geneartion for special struct members X and a

### DIFF
--- a/tests/special_characters/funny-proto+name has.characters.proto
+++ b/tests/special_characters/funny-proto+name has.characters.proto
@@ -1,1 +1,21 @@
 syntax="proto2";
+
+message WorkingMessage {
+        required int32 b = 1;
+        required int32 Z = 2;
+}
+
+message FailingMessageBecauseMembersAreMacroParameter {
+        required int32 a = 1;
+        required int32 X = 2;
+}
+
+message TestMacroParametersAndUnderscores {
+        required int32 a     = 1;
+        required int32 a_    = 2;
+        required int32 X     = 3;
+        required int32 X_    = 4;
+        required int32 X__   = 5;
+        required int32 X___  = 6;
+        required int32 X____ = 7;
+}


### PR DESCRIPTION
Hello,
while using nanopb I noticed a bug in the python generator. I think my extended special character test case should make clear what the problem is. However, I try to put it in words below. 

Naming message (struct) members in a .proto file `X` or `a` crashes with the automatic `message_FIELDLIST` macro generation of the nanopb python generator.  The macro uses `X` and `a` as parameters. If the generated *.pb.[ch] files are now compiled, the preprocessor will replace also the member name in the macro which is IMO not intended.

In most cases a .proto snippet
```
message SimpleMessage {
    required int32 fieldname = 1;
}
```
is converted to a macro like this
```
#define X_FIELDLIST(X, a) \
X(a, STATIC,   REQUIRED, INT32,    fieldname,                 1)
```
However, using the following proto snippet with `a` as member
```
message SimpleMessage {
    required int32 a = 1;
}
```
leads to the following unwanted macro where two `a`s exist:
```
#define X_FIELDLIST(X, a) \
X(a, STATIC,   REQUIRED, INT32,    a,                 1)
```


I extended the special character test .proto file to recreate the bug in the first commit. The second commit makes the test pass by checking if the parameters `X` and `a` of the macro are a field name. If they are a field name, the generator now appends underscores to `X` or `a` until they don't match any field name. The fixed versions produces the following macro from the second .proto snippet:
```
#define X_FIELDLIST(X, a_) \
X(a_, STATIC,   REQUIRED, INT32,    a,                 1)
```

I hope this is helpful.

Best regards
Ket3r