### PR TITLE
Added type_override option, and its handling to generator

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -417,6 +417,9 @@ class Field:
         else:
             raise NotImplementedError(field_options.type)
 
+        if field_options.HasField("type_override"):
+            desc.type = field_options.type_override
+
         # Decide the C data type to use in the struct.
         if desc.type in datatypes:
             self.ctype, self.pbtype, self.enc_size, self.data_item_size = datatypes[desc.type]

--- a/generator/proto/nanopb.proto
+++ b/generator/proto/nanopb.proto
@@ -138,6 +138,9 @@ message NanoPBOptions {
 
   // Package name that applies only for nanopb.
   optional string package = 25;
+  
+  // Override type of the field in generated C code. Only to be used with related field types
+  optional google.protobuf.FieldDescriptorProto.Type type_override = 27;
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options

--- a/tests/options/options.proto
+++ b/tests/options/options.proto
@@ -110,3 +110,10 @@ message HasFieldMessage
     optional int32 missing = 2 [(nanopb).default_has = false];
     optional int32 normal = 3;
 }
+
+// Overriden type in generated C code
+message TypeOverrideMessage
+{
+    required Enum1 normal = 1;
+    required Enum1 overriden = 2 [(nanopb).type_override = TYPE_UINT32];
+}

--- a/tests/options/options_h.expected
+++ b/tests/options/options_h.expected
@@ -17,4 +17,8 @@ Message5_EnumValue1
 \s+PB_MSG\(105,[0-9]*,Message5\) \\
 #define Message5_msgid 105
 ! has_proto3field
+Enum1 normal
+uint32_t overriden
+#define TypeOverrideMessage_init_default[ ]*\{_Enum1_MIN, 0\}
+#define TypeOverrideMessage_init_zero[ ]*\{_Enum1_MIN, 0\}
 


### PR DESCRIPTION
I propose to add an option, which would allow to override type of variable in generated C structs.

It is useful, if you have many different types of (enum) fields, but want them to be of the same type in C. This allows to use a single method to update field values, or store pointers to these fields in an array.

Of course, using this option requires extra carefulness, because mismatching an override type will result in all sorts of issues. Although, anyone, who has a need for such options, will likely be aware of the possible consequences