### PR TITLE
Fix adding the -I option to protoc exec

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1935,7 +1935,7 @@ def main_cli():
         if filename.endswith(".proto"):
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmpname = os.path.join(tmpdir, os.path.basename(filename) + ".pb")
-                invoke_protoc(["protoc"] + include_path + ['-o' + tmpname, filename])
+                invoke_protoc(["protoc"] + include_path + ['-o' + tmpname, '-I'+os.path.dirname(os.path.realpath(filename)),filename])
                 data = open(tmpname, 'rb').read()
         else:
             data = open(filename, 'rb').read()


### PR DESCRIPTION
## Issue

The newest version of protoc requires the -I flag to be used otherwise you get the following output-

```
File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).
```

## Solution

Line 1938 modified to pass a `-I` and the protobuf directory `'-I'+os.path.dirname(os.path.realpath(filename))` testing working with a .proto file on OpenSUSE linux. **Please note I was unable to run the scons tests so I would recommend that is done before a merge**.