### PR TITLE
Regression test + fix for proto3 submessage improperly considered empty

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -304,6 +304,12 @@ static bool pb_check_proto3_default_value(const pb_field_t *field, const void *p
             return true;
         }
     }
+
+    /* Compares pointers to NULL in case of FT_POINTER */
+    if (PB_ATYPE(type) == PB_ATYPE_POINTER && PB_LTYPE(type) > PB_LTYPE_LAST_PACKABLE)
+    {
+        return !*(const void**)((uintptr_t)pData);
+    }
     
 	{
 	    /* Catch-all branch that does byte-per-byte comparison for zero value.

--- a/tests/regression/issue_504/SConscript
+++ b/tests/regression/issue_504/SConscript
@@ -1,0 +1,12 @@
+# Regression test for #504:
+# Non empty submessage considered empty on FT_POINTER fields with address aligned on 0x100
+
+Import('env', 'malloc_env')
+
+env.NanopbProto(["test.proto"])
+test = malloc_env.Program(["test.c",
+                 "test.pb.c",
+                 "$COMMON/pb_encode.o",
+                 "$COMMON/pb_common.o"])
+
+env.RunTest(test)

--- a/tests/regression/issue_504/test.c
+++ b/tests/regression/issue_504/test.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pb_encode.h>
+#include "test.pb.h"
+#include "unittests.h"
+
+const char STR[] = "test str";
+#define ALIGN 0x100
+
+int main(int argc, char **argv)
+{
+    int status = 0;
+    uint8_t buffer[512] = {0};
+    int i;
+    pb_ostream_t ostream;
+    MyMessage msg = MyMessage_init_zero;
+    char *pStr, *pStrAligned;
+    ostream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+    /* copy STR to a malloced 0x100 aligned address */
+    pStr = malloc(sizeof(STR) + ALIGN);
+    pStrAligned = (char*)((uintptr_t)(pStr + ALIGN) & ~(ALIGN - 1));
+    memcpy(pStrAligned, STR, sizeof(STR));
+
+    msg.submessage.somestring = pStrAligned;
+    printf("%p: '%s'\n", msg.submessage.somestring, msg.submessage.somestring);
+
+    if (!pb_encode(&ostream, MyMessage_fields, &msg)) {
+        fprintf(stderr, "Encode failed: %s\n", PB_GET_ERROR(&ostream));
+        return 1;
+    }
+
+    free(pStr);
+    msg.submessage.somestring = NULL;
+
+    printf("response payload (%d):", (int)ostream.bytes_written);
+    for (i = 0; i < ostream.bytes_written; i++) {
+        printf("%02X", buffer[i]);
+    }
+    printf("\n");
+
+    TEST(ostream.bytes_written != 0);
+
+    return status;
+}
+

--- a/tests/regression/issue_504/test.proto
+++ b/tests/regression/issue_504/test.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "nanopb.proto";
+
+message MyMessage
+{
+    SubMessage submessage = 1;
+}
+
+message SubMessage
+{
+    string somestring = 1 [(nanopb).type = FT_POINTER];
+}


### PR DESCRIPTION
**Steps to reproduce the issue**

See the attached test case

**What happens?**

On `pb_encode`, `pb_check_proto3_default_value` may improperly consider submessages as being empty (set to  default value) when FT_POINTER fields are used.

It is only checking the `field->data_size` first byte(s) of the pointer, which for strings or bytes is 1, so if an pointer happens to be aligned on 0x100 it'll be considered as being NULL.

**What should happen?**

Non empty submessages should always be serialized.

**Notes**
Fixing PB_SINGULAR_POINTER `field->data_size` to actually be a full pointer size seems to work without breaking other tests cases `pb_membersize(st, m[0])` -> `pb_membersize(st, m)`. But this leads to OOBW on `pb_decode`.

This bug is not present in 0.4 and onward thanks to `has_submessage`.