### PR TITLE
Use Nanopb as cmake package name.

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -338,7 +338,7 @@ mark_as_advanced(NANOPB_GENERATOR_SOURCE_DIR)
 find_package(PythonInterp REQUIRED)
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NANOPB DEFAULT_MSG
+find_package_handle_standard_args(Nanopb DEFAULT_MSG
   NANOPB_INCLUDE_DIRS
   NANOPB_SRCS NANOPB_HDRS
   NANOPB_GENERATOR_SOURCE_DIR


### PR DESCRIPTION
* As cmake find file is named 'FindNanopb.cmake' users are required
  to use `find_package(Nanopb)` to find nanopb. cmake >= 3.17 warns
  if package name (NANOPB up to now) and name used within find_package
  to not match. This changes to name to Nanopb. As the found variable
  is always with with UPPERCASE as well, this should be backwards
  compatible for users.
* Fixes Issue #506