### PR TITLE
use split --nanopb_opt only on Windows

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -249,6 +249,13 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
         set(NANOPB_PLUGIN_OPTIONS "${NANOPB_PLUGIN_OPTIONS} ${NANOPB_OPTIONS}")
     endif()
 
+    # There is a problem with ':' as option separator in protoc args so deal with it by splitting the options
+    # However this requires a version of protoc >= 3.6 so keep the old behavior for non-windows systems
+    if(CMAKE_HOST_SYSTEM MATCHES "Windows")
+        set(NANOPB_OPT_STRING "--nanopb_opt=${NANOPB_PLUGIN_OPTIONS}" "--nanopb_out=${CMAKE_CURRENT_BINARY_DIR}")
+    else()
+      set(NANOPB_OPT_STRING "--nanopb_out=${NANOPB_PLUGIN_OPTIONS}:${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_PATH_REL}/${FIL_WE}.pb.c"
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_PATH_REL}/${FIL_WE}.pb.h"
@@ -256,8 +263,8 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
       ARGS -I${GENERATOR_PATH} -I${GENERATOR_CORE_DIR}
            -I${CMAKE_CURRENT_BINARY_DIR} ${_nanopb_include_path}
            --plugin=protoc-gen-nanopb=${NANOPB_GENERATOR_PLUGIN}
-           "--nanopb_opt=${NANOPB_PLUGIN_OPTIONS}"
-           "--nanopb_out=${CMAKE_CURRENT_BINARY_DIR}" ${ABS_FIL}
+            ${NANOPB_OPT_STRING}
+            ${ABS_FIL}
       DEPENDS ${ABS_FIL} ${GENERATOR_CORE_PYTHON_SRC}
            ${NANOPB_OPTIONS_FILE} ${NANOPB_DEPENDS}
       COMMENT "Running C++ protocol buffer compiler using nanopb plugin on ${FIL}"

--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -249,7 +249,8 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
         set(NANOPB_PLUGIN_OPTIONS "${NANOPB_PLUGIN_OPTIONS} ${NANOPB_OPTIONS}")
     endif()
 
-    set(NANOPB_OUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_PATH_REL}")
+    # based on the version of protoc it might be necessary to add "/${FIL_PATH_REL}" currently dealt with in #516
+    set(NANOPB_OUT "${CMAKE_CURRENT_BINARY_DIR}")
 
     # We need to pass the path to the option files to the nanopb plugin. There are two ways to do it.
     # - An older hacky one using ':' as option separator in protoc args preventing the ':' to be used in path.

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1792,7 +1792,7 @@ optparser.add_option("-I", "--options-path", dest="options_path", metavar="DIR",
 optparser.add_option("--error-on-unmatched", dest="error_on_unmatched", action="store_true", default=False,
                      help ="Stop generation if there are unmatched fields in options file")
 optparser.add_option("--no-error-on-unmatched", dest="error_on_unmatched", action="store_false", default=False,
-                     help ="Continue generation if there are unmatched fields in options file")
+                     help ="Continue generation if there are unmatched fields in options file (default)")
 optparser.add_option("-D", "--output-dir", dest="output_dir",
                      metavar="OUTPUTDIR", default=None,
                      help="Output directory of .pb.h and .pb.c files")


### PR DESCRIPTION
 to allow other systems without the ':' in their path to use older versions of protoc
