### PR TITLE
Fix nanopb_out path in cmake command

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -257,7 +257,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
            -I${CMAKE_CURRENT_BINARY_DIR} ${_nanopb_include_path}
            --plugin=protoc-gen-nanopb=${NANOPB_GENERATOR_PLUGIN}
            "--nanopb_opt=${NANOPB_PLUGIN_OPTIONS}"
-           "--nanopb_out=${CMAKE_CURRENT_BINARY_DIR}" ${ABS_FIL}
+           "--nanopb_out=${CMAKE_CURRENT_BINARY_DIR}/${FIL_PATH_REL}" ${ABS_FIL}
       DEPENDS ${ABS_FIL} ${GENERATOR_CORE_PYTHON_SRC}
            ${NANOPB_OPTIONS_FILE} ${NANOPB_DEPENDS}
       COMMENT "Running C++ protocol buffer compiler using nanopb plugin on ${FIL}"


### PR DESCRIPTION
The custom command currently claims to output a file with the relative path included, but actually creates a file without the relative path.

This change creates files in the relative path directory.