### PR TITLE
Relax cmake python interpreter requirements to support Python3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,9 @@ endif()
 if(nanopb_BUILD_GENERATOR)
     set(generator_protos nanopb)
 
-    find_package(PythonInterp 2.7 REQUIRED)
+    find_package(Python REQUIRED)
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -c
+        COMMAND ${Python_EXECUTABLE} -c
             "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -60,7 +60,7 @@ if(nanopb_BUILD_GENERATOR)
         add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})
         install(
             FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
-			DESTINATION ${PYTHON_INSTDIR}
+            DESTINATION ${Python_SITELIB}
         )
     endforeach()
 endif()


### PR DESCRIPTION
This removes the Python 2.7 interpreter requirement for `cmake` and fixes issues when build systems may be using nanopb but no longer support Python 2.

**Steps to reproduce the issue**
* Run `cmake .` on a system without Python 2.7, or
* Integrate into a build system that installs required packages for Python3

**What happens?**
* cmake fails to find an appropriate python version, or
* Building fails since required packages may not be installed for Python 2.7

**What should happen?**
* cmake should use the default Python interpreter
