### PR TITLE
Fix nanopb_generator exception on enums with aliases

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -176,6 +176,11 @@ class Names:
     def __eq__(self, other):
         return isinstance(other, Names) and self.parts == other.parts
 
+    def __lt__(self, other):
+        if not isinstance(other, Names):
+            return NotImplemented
+        return str(self) < str(other)
+
 def names_from_type_name(type_name):
     '''Parse Names() from FieldDescriptorProto type_name'''
     if type_name[0] != '.':

--- a/tests/regression/issue_535/SConscript
+++ b/tests/regression/issue_535/SConscript
@@ -1,0 +1,6 @@
+# Regression test for #535:
+# Generator crash on enums with aliases
+
+Import("env")
+env.NanopbProto("issue_535")
+env.Object("issue_535.pb.c")

--- a/tests/regression/issue_535/issue_535.proto
+++ b/tests/regression/issue_535/issue_535.proto
@@ -1,0 +1,10 @@
+/* Test generation of enums with aliases */
+
+syntax = "proto3";
+
+enum EnumWithAliases {
+  option allow_alias = true;
+  First = 0;
+  Second = 1;
+  AlsoSecond = 1;
+}


### PR DESCRIPTION
Protobuf:

```proto
syntax = "proto3";

enum Foo {
  option allow_alias = true;
  Bar = 0;
  Baz = 1;
  Bag = 1;
}
```

Gives this exception:
```
$ nanopb_generator -D src test.proto 
Traceback (most recent call last):
  File "/usr/local/bin/nanopb_generator", line 8, in <module>
    sys.exit(main_cli())
  File "/home/tassadar/.local/lib/python3.8/site-packages/nanopb/generator/nanopb_generator.py", line 1929, in main_cli
    results = process_file(fdesc.name, fdesc, options, other_files)
  File "/home/tassadar/.local/lib/python3.8/site-packages/nanopb/generator/nanopb_generator.py", line 1866, in process_file
    headerdata = ''.join(f.generate_header(includes, headerbasename, options))
  File "/home/tassadar/.local/lib/python3.8/site-packages/nanopb/generator/nanopb_generator.py", line 1500, in generate_header
    yield enum.auxiliary_defines() + '\n'
  File "/home/tassadar/.local/lib/python3.8/site-packages/nanopb/generator/nanopb_generator.py", line 268, in auxiliary_defines
    sorted_values = sorted(self.values, key = lambda x: (x[1], x[0]))
TypeError: '<' not supported between instances of 'Names' and 'Names'
```

Only happens on Python3.