### PR TITLE
Disabled 64bit data type and error messages - Save some flash space

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -25,14 +25,14 @@
 /* #define PB_FIELD_32BIT 1 */
 
 /* Disable support for error messages in order to save some code space. */
-/* #define PB_NO_ERRMSG 1 */
+#define PB_NO_ERRMSG 1
 
 /* Disable support for custom streams (support only memory buffers). */
 /* #define PB_BUFFER_ONLY 1 */
 
 /* Disable support for 64-bit datatypes, for compilers without int64_t
    or to save some code space. */
-/* #define PB_WITHOUT_64BIT 1 */
+#define PB_WITHOUT_64BIT 1
 
 /* Don't encode scalar arrays as packed. This is only to be used when
  * the decoder on the receiving side cannot process packed scalar arrays.
@@ -238,7 +238,7 @@ typedef uint_least8_t pb_type_t;
 #define PB_HTYPE_MASK     0x30U
 
 /**** Field allocation types ****/
- 
+
 #define PB_ATYPE_STATIC   0x00U
 #define PB_ATYPE_POINTER  0x80U
 #define PB_ATYPE_CALLBACK 0x40U
@@ -364,7 +364,7 @@ struct pb_callback_s {
         bool (*decode)(pb_istream_t *stream, const pb_field_t *field, void **arg);
         bool (*encode)(pb_ostream_t *stream, const pb_field_t *field, void * const *arg);
     } funcs;
-    
+
     /* Free arg for use by callback */
     void *arg;
 };
@@ -396,7 +396,7 @@ struct pb_extension_type_s {
      */
     bool (*decode)(pb_istream_t *stream, pb_extension_t *extension,
                    uint32_t tag, pb_wire_type_t wire_type);
-    
+
     /* Called once after all regular fields have been encoded.
      * If you have something to write, do so and return true.
      * If you do not have anything to write, just return true.
@@ -404,7 +404,7 @@ struct pb_extension_type_s {
      * Set to NULL for default handler.
      */
     bool (*encode)(pb_ostream_t *stream, const pb_extension_t *extension);
-    
+
     /* Free field for use by the callback. */
     const void *arg;
 };
@@ -413,11 +413,11 @@ struct pb_extension_s {
     /* Type describing the extension field. Usually you'll initialize
      * this to a pointer to the automatically generated structure. */
     const pb_extension_type_t *type;
-    
+
     /* Destination for the decoded data. This must match the datatype
      * of the extension field. */
     void *dest;
-    
+
     /* Pointer to the next extension handler, or NULL.
      * If this extension does not match a field, the next handler is
      * automatically called. */
@@ -827,4 +827,3 @@ template <typename GenMessageT> struct MessageDescriptor;
 #endif  /* __cplusplus */
 
 #endif
-


### PR DESCRIPTION
To reduce flash code size on embedded devices, we are disabling support for 64 bit fields and error messages.