### PR TITLE
Add support for infinity and nan floating-point defaults (#530)

### DIFF
--- a/tests/infinity_nan/SConscript
+++ b/tests/infinity_nan/SConscript
@@ -1,0 +1,8 @@
+# Build and run a basic test for floating point default values.
+
+Import("env")
+
+env.NanopbProto("floats")
+test = env.Program(["infinity_nan_test.c", "floats.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_common.o"])
+
+env.RunTest(test)

--- a/tests/infinity_nan/floats.proto
+++ b/tests/infinity_nan/floats.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+message Floats {
+    optional float float_pos_inf = 1 [default = inf];
+    optional float float_neg_inf = 2 [default = -inf];
+    optional float float_pos_nan = 3 [default = nan];
+    optional float float_neg_nan = 4 [default = -nan];
+    optional double double_pos_inf = 5 [default = inf];
+    optional double double_neg_inf = 6 [default = -inf];
+    optional double double_pos_nan = 7 [default = nan];
+    optional double double_neg_nan = 8 [default = -nan];
+}

--- a/tests/infinity_nan/infinity_nan_test.c
+++ b/tests/infinity_nan/infinity_nan_test.c
@@ -1,0 +1,62 @@
+/* Tests for floating point default values +-infinity and nan. */
+#undef __STRICT_ANSI__
+#include <math.h>
+#include <pb_decode.h>
+#include "floats.pb.h"
+#include "unittests.h"
+
+bool check_floats(Floats *floats)
+{
+    int status = 0;
+
+    TEST(!floats->has_float_pos_inf);
+    TEST(isinf(floats->float_pos_inf));
+    TEST(!signbit(floats->float_pos_inf));
+
+    TEST(!floats->has_float_neg_inf);
+    TEST(isinf(floats->float_neg_inf));
+    TEST(signbit(floats->float_neg_inf));
+
+    TEST(!floats->has_float_pos_nan);
+    TEST(isnan(floats->float_pos_nan));
+
+    TEST(!floats->has_float_neg_nan);
+    TEST(isnan(floats->float_neg_nan));
+
+    TEST(!floats->has_double_pos_inf);
+    TEST(isinf(floats->double_pos_inf));
+    TEST(!signbit(floats->double_pos_inf));
+
+    TEST(!floats->has_double_neg_inf);
+    TEST(isinf(floats->double_neg_inf));
+    TEST(signbit(floats->double_neg_inf));
+
+    TEST(!floats->has_double_pos_nan);
+    TEST(isnan(floats->double_pos_nan));
+
+    TEST(!floats->has_double_neg_nan);
+    TEST(isnan(floats->double_neg_nan));
+
+    return status == 0;
+}
+
+int main()
+{
+    int status = 0;
+
+    {
+        Floats floats = Floats_init_default;
+        COMMENT("Checking init_default");
+        TEST(check_floats(&floats));
+    }
+
+    {
+        Floats floats = {0};
+        pb_istream_t stream = pb_istream_from_buffer(NULL, 0);
+        COMMENT("Check decoded");
+        TEST(pb_decode(&stream, Floats_fields, &floats));
+        TEST(check_floats(&floats));
+    }
+
+    return status;
+}


### PR DESCRIPTION
Fix for https://github.com/nanopb/nanopb/issues/530.

The proto2 spec allows floating-point fields to have default values of 'inf', '-inf', 'nan' or '-nan'. The generator script copies these directly into source code, where they fail to compile (they do parse correctly in Python).

This change adds the following conversions for generated C code:
inf -> INFINITY
nan -> NAN
and adds an include for <math.h> where one of these occurs.

Note: The macros INFINITY and NAN are C99 features, so this won't work for strict ANSI C. However, the user can supply their own macro definitions in that case.