### PR TITLE
Install missing _utils.py and binary/wrappers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,27 @@ if(nanopb_BUILD_GENERATOR)
         add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})
         install(
             FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
-            DESTINATION ${PYTHON_INSTDIR}
+                  ${generator_proto_file}
+            DESTINATION ${PYTHON_INSTDIR}/proto/
         )
     endforeach()
+endif()
+
+install( FILES generator/proto/_utils.py
+         DESTINATION ${PYTHON_INSTDIR}/proto/ )
+
+if( WIN32 )
+        install(
+            PROGRAMS generator/nanopb_generator.py
+                     generator/protoc-gen-nanopb.bat
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+else()
+        install(
+            PROGRAMS generator/nanopb_generator.py
+                     generator/protoc-gen-nanopb
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
 endif()
 
 if(nanopb_BUILD_RUNTIME)


### PR DESCRIPTION
This patch installs the missing _utils.py and nanopb_pb2.py into the
expected proto/ subfolder.  Otherwise the generator script imports will
not find them in the proper namespace.

It also installs the generator and wrapper scripts in
CMAKE_PREFIX_PATH/bin/. WIN32 is handled specially since it has a
separate wrapper (.bat).