### PR TITLE
Update conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ class NanoPbConan(ConanFile):
     license = "zlib"
     url = "https://jpa.kapsi.fi/nanopb/"
     description = "Protocol Buffers with small code size"
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os_build", "compiler", "build_type", "arch"
     generators = "cmake"
     exports = '*'
     options = {
@@ -18,7 +18,7 @@ class NanoPbConan(ConanFile):
     }
 
     def configure(self):
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+        if self.settings.os_build == "Windows" and self.settings.compiler == "Visual Studio":
             del self.options.fPIC
 
     def build(self):


### PR DESCRIPTION
settings.os represent the target system not the build system (https://docs.conan.io/en/latest/systems_cross_building/cross_building.html#gnu-triplet-convention).
Thus we need to check the `settings_os_build` variable not the `os` variable.
This will fix the problem that CMake tries to check if the compiler works with wrong parameter (which results in using -`rdynamic` which may not be supported on mcu compilers)