### PR TITLE
Better support C++ types in generated structs

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1541,8 +1541,12 @@ class ProtoFile:
         yield '\n'
 
         for incfile in self.file_options.include:
-            yield options.genformat % incfile
-            yield '\n'
+            # allow including system headers
+            if (incfile.startswith('<')):
+                yield '#include %s\n' % incfile
+            else:
+                yield options.genformat % incfile
+                yield '\n'
 
         for incfile in includes:
             noext = os.path.splitext(incfile)[0]
@@ -1558,10 +1562,6 @@ class ProtoFile:
         yield '#error Regenerate this file with the current version of nanopb generator.\n'
         yield '#endif\n'
         yield '\n'
-
-        yield '#ifdef __cplusplus\n'
-        yield 'extern "C" {\n'
-        yield '#endif\n\n'
 
         if self.enums:
             yield '/* Enum definitions */\n'
@@ -1586,6 +1586,10 @@ class ProtoFile:
                 for enum in self.enums:
                     yield enum.auxiliary_defines() + '\n'
                 yield '\n'
+
+        yield '#ifdef __cplusplus\n'
+        yield 'extern "C" {\n'
+        yield '#endif\n\n'
 
         if self.messages:
             yield '/* Initializer values for message structs */\n'

--- a/tests/cxx_callback_datatype/SConscript
+++ b/tests/cxx_callback_datatype/SConscript
@@ -1,0 +1,32 @@
+Import('env')
+
+import os
+
+base_env = env.Clone()
+base_env.Replace(NANOPBFLAGS = '--cpp-descriptor')
+# NOTE: base_env.Replace(NANOPBFLAGS = '--source-extension=.cc,--cpp-descriptor')
+# does not work. Looks like tests/site_scons/site_tools/nanopb.py:_nanopb_proto_builder forces '.c' suffix
+base_env.NanopbProto('message')
+
+# Workaround...
+# Copy the files to .cxx extension in order to force C++ build.
+c = Copy("$TARGET", "$SOURCE")
+env.Command("message.pb.cc", "$BUILD/cxx_callback_datatype/message.pb.c", c)
+
+for std in ["c++03", "c++11", "c++14", "c++17", "c++20"]:
+    e = base_env.Clone()
+    e.Append(CXXFLAGS = '-std={}'.format(std))
+
+    # Make sure compiler supports this version of C++ before we actually run the
+    # test.
+    conf = Configure(e)
+    compiler_valid = conf.CheckCXX()
+    e = conf.Finish()
+    if not compiler_valid:
+        print("Skipping {} test - compiler doesn't support it".format(std))
+        continue
+
+    sources = [ 'cxx_callback_datatype.cc', 'message.pb.cc', '$NANOPB/pb_decode.c', '$NANOPB/pb_encode.c', '$NANOPB/pb_common.c' ]
+    objects = [ e.Object('{}_{}'.format(os.path.basename(s), std), s) for s in sources ]
+    p = e.Program(target = 'cxx_callback_datatype_{}'.format(std), source = objects)
+    e.RunTest(p)

--- a/tests/cxx_callback_datatype/SConscript
+++ b/tests/cxx_callback_datatype/SConscript
@@ -4,14 +4,7 @@ import os
 
 base_env = env.Clone()
 base_env.Replace(NANOPBFLAGS = '--cpp-descriptor')
-# NOTE: base_env.Replace(NANOPBFLAGS = '--source-extension=.cc,--cpp-descriptor')
-# does not work. Looks like tests/site_scons/site_tools/nanopb.py:_nanopb_proto_builder forces '.c' suffix
-base_env.NanopbProto('message')
-
-# Workaround...
-# Copy the files to .cxx extension in order to force C++ build.
-c = Copy("$TARGET", "$SOURCE")
-env.Command("message.pb.cc", "$BUILD/cxx_callback_datatype/message.pb.c", c)
+base_env.NanopbProtoCpp('message')
 
 for std in ["c++03", "c++11", "c++14", "c++17", "c++20"]:
     e = base_env.Clone()
@@ -26,7 +19,7 @@ for std in ["c++03", "c++11", "c++14", "c++17", "c++20"]:
         print("Skipping {} test - compiler doesn't support it".format(std))
         continue
 
-    sources = [ 'cxx_callback_datatype.cc', 'message.pb.cc', '$NANOPB/pb_decode.c', '$NANOPB/pb_encode.c', '$NANOPB/pb_common.c' ]
+    sources = [ 'cxx_callback_datatype.cpp', 'message.pb.cpp', '$NANOPB/pb_decode.c', '$NANOPB/pb_encode.c', '$NANOPB/pb_common.c' ]
     objects = [ e.Object('{}_{}'.format(os.path.basename(s), std), s) for s in sources ]
     p = e.Program(target = 'cxx_callback_datatype_{}'.format(std), source = objects)
     e.RunTest(p)

--- a/tests/cxx_callback_datatype/cxx_callback_datatype.cc
+++ b/tests/cxx_callback_datatype/cxx_callback_datatype.cc
@@ -1,0 +1,91 @@
+#include "message.pb.h"
+
+#include <pb_encode.h>
+#include <pb_decode.h>
+
+#include <cstdio>
+
+// See tests/alltypes_callback, tests/oneoff_callback and examples/network_server for more...
+bool TestMessage_submessages_callback(pb_istream_t *istream, pb_ostream_t *ostream, const pb_field_t *field)
+{
+	if (ostream != NULL) {
+		const std::vector<int> &v = *(const std::vector<int> *)field->pData;
+		for (std::vector<int>::const_iterator i = v.begin(); i != v.end(); ++i) {
+			if (!pb_encode_tag_for_field(ostream, field)) {
+				return false;
+			}
+			SubMessage tmp;
+			tmp.actual_value = *i;
+			if (!pb_encode_submessage(ostream, SubMessage_fields, &tmp)) {
+				return false;
+			}
+		}
+	} else if (istream != NULL) {
+		std::vector<int> &v = *(std::vector<int> *)field->pData;
+		SubMessage tmp;
+		if (!pb_decode(istream, SubMessage_fields, &tmp)) {
+			return false;
+		}
+		v.push_back(tmp.actual_value);
+	}
+	return true;
+}
+
+extern "C"
+bool TestMessage_callback(pb_istream_t *istream, pb_ostream_t *ostream, const pb_field_t *field)
+{
+	if (field->tag == TestMessage_submessages_tag) {
+		return TestMessage_submessages_callback(istream, ostream, field);
+	}
+	return true;
+}
+
+extern "C"
+int main() {
+	std::vector<int> source;
+	source.push_back(5);
+	source.push_back(4);
+	source.push_back(3);
+	source.push_back(2);
+	source.push_back(1);
+
+
+	std::vector<uint8_t> serialized;
+	pb_ostream_t sizestream = {0};
+	pb_encode(&sizestream, TestMessage_fields, &source);
+	serialized.resize(sizestream.bytes_written);
+	pb_ostream_t outstream = pb_ostream_from_buffer(&serialized.front(), serialized.size());
+	if (!pb_encode(&outstream, TestMessage_fields, &source)) {
+		fprintf(stderr, "Failed to encode: %s\n", PB_GET_ERROR(&outstream));
+		return 1;
+	}
+
+
+	std::vector<int> destination;
+	pb_istream_t instream = pb_istream_from_buffer(&serialized.front(), outstream.bytes_written);
+	if (!pb_decode(&instream, TestMessage_fields, &destination)) {
+		fprintf(stderr, "Failed to decode: %s\n", PB_GET_ERROR(&instream));
+		return 2;
+	}
+	if (source != destination) {
+		fprintf(stderr, "Result does not match\n");
+		fprintf(stderr, "source(%lu): ", source.size());
+		for (std::vector<int>::iterator i = source.begin(); i != source.end(); ++i)
+		{
+			fprintf(stderr, "%d, ", *i);
+		}
+		fprintf(stderr, "\nencoded(%lu): ", serialized.size());
+		for (unsigned i = 0; i != std::min(serialized.size(), outstream.bytes_written); ++i) {
+			fprintf(stderr, "%#06x ", serialized[i]);
+		}
+		fprintf(stderr, "\ndestination(%lu): ", destination.size());
+		for (std::vector<int>::iterator i = destination.begin(); i != destination.end(); ++i)
+		{
+			fprintf(stderr, "%d, ", *i);
+		}
+		fprintf(stderr, "\n");
+		return 3;
+	}
+
+	return 0;
+}

--- a/tests/cxx_callback_datatype/cxx_callback_datatype.cpp
+++ b/tests/cxx_callback_datatype/cxx_callback_datatype.cpp
@@ -1,4 +1,4 @@
-#include "message.pb.h"
+#include "message.pb.hpp"
 
 #include <pb_encode.h>
 #include <pb_decode.h>

--- a/tests/cxx_callback_datatype/message.proto
+++ b/tests/cxx_callback_datatype/message.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "nanopb.proto";
+
+option(nanopb_fileopt).include = '<vector>';
+
+message SubMessage {
+  sint32 actual_value = 1;
+}
+
+message TestMessage {
+  // Instead of std::vector<SubMessage> callback handles wrapping/unwrapping of the int.
+  repeated SubMessage submessages = 1 [(nanopb).callback_datatype = "std::vector<int>"];
+}


### PR DESCRIPTION
Option '(nanopb).callback_datatype' does not work with
most C++ types, because generated structure is inside
an 'extern "C" {' block, that prevents using namespaces, templates...

Option '(nanopb_fileopt).include' does not support including system headers,
that prevents using `<vector>`, `<string>`, etc...

Modify generator in following ways:

- start 'extern "C" {' later, after the structures

- for include option stating with `'<'`, include system header
e.g. `"(nanopb_fileopt).include = '<vector>'"` generates `"#include <vector>"`

Add 'cxx_callback_datatype', SConscript code based on 'cxx_descriptor' test.