### PR TITLE
SPM: Fix iOS Build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,6 @@ import PackageDescription
 
 let package = Package(
   name: "nanopb",
-    platforms: [
-        .macOS(.v10_10),
-        .iOS(.v8),
-        .tvOS(.v9),
-        .watchOS(.v2)
-    ],
-
   products: [
     .library(
       name: "nanopb",


### PR DESCRIPTION
The platform specifications cause a build warning in Xcode 12. They're not necessary since nanopb supports all versions supported by Xcode versions that support Swift Package Manager.

Details in https://github.com/firebase/firebase-ios-sdk/issues/6449, https://forums.swift.org/t/minimum-ios-version-xcode-12-and-build-warnings/40224, and https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md