### PR TITLE
Allow multiple targets to be created by calling NANOPB_GENERATE_CPP()

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -149,7 +149,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
 
   list(REMOVE_DUPLICATES _nanopb_include_path)
 
-  set(GENERATOR_PATH ${CMAKE_BINARY_DIR}/nanopb/generator)
+  set(GENERATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/nanopb/generator)
 
   set(NANOPB_GENERATOR_EXECUTABLE ${GENERATOR_PATH}/nanopb_generator.py)
   if (CMAKE_HOST_WIN32)


### PR DESCRIPTION
When calling NANOPB_GENERATE_CPP() multiple times with cmake ninja generator, one will run into following issue:
```
ninja: error: build.ninja:14698: multiple rules generate nanopb/generator/proto/nanopb_pb2.py [-w dupbuild=err
```