### PR TITLE
Add protobuf-nanopb library to cpp_info.libs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -30,3 +30,4 @@ class NanoPbConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = ["include"]
         self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.libs = ["protobuf-nanopb"]


### PR DESCRIPTION
Without this, there will be no links against the nanopb library when
nanopb is integrated by conan
Fixes #604 