### PR TITLE
Add '--version' option to nanopb_generator.py

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2114,6 +2114,10 @@ def main_plugin():
         optparser.print_help(sys.stderr)
         sys.exit(1)
 
+    if '--version' in args:
+        sys.stderr.write('%s\n' % (nanopb_version))
+        sys.exit(0)
+
     options, dummy = optparser.parse_args(args)
 
     Globals.verbose_options = options.verbose

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1856,6 +1856,8 @@ optparser = OptionParser(
     usage = "Usage: nanopb_generator.py [options] file.pb ...",
     epilog = "Compile file.pb from file.proto by: 'protoc -ofile.pb file.proto'. " +
              "Output will be written to file.pb.h and file.pb.c.")
+optparser.add_option("--version", dest="version", action="store_true",
+    help="Show version info and exit")
 optparser.add_option("-x", dest="exclude", metavar="FILE", action="append", default=[],
     help="Exclude file from generated #include list.")
 optparser.add_option("-e", "--extension", dest="extension", metavar="EXTENSION", default=".pb",
@@ -2004,6 +2006,10 @@ def main_cli():
     '''Main function when invoked directly from the command line.'''
 
     options, filenames = optparser.parse_args()
+
+    if options.version:
+        print(nanopb_version)
+        sys.exit(0)
 
     if not filenames:
         optparser.print_help()

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2114,11 +2114,11 @@ def main_plugin():
         optparser.print_help(sys.stderr)
         sys.exit(1)
 
-    if '--version' in args:
+    options, dummy = optparser.parse_args(args)
+
+    if options.version:
         sys.stderr.write('%s\n' % (nanopb_version))
         sys.exit(0)
-
-    options, dummy = optparser.parse_args(args)
 
     Globals.verbose_options = options.verbose
 


### PR DESCRIPTION
As requested in #603 ,

New option "--version" was added to nanopb_generator.py that will print nanopb's version and exit.

This option is supported in both CLI and protoc-plugin mode.
