### PR TITLE
docs: fix simple typo, specifing -> specifying

### DIFF
--- a/pb_encode.h
+++ b/pb_encode.h
@@ -132,7 +132,7 @@ bool pb_write(pb_ostream_t *stream, const pb_byte_t *buf, size_t count);
  * structure. Call this from the callback before writing out field contents. */
 bool pb_encode_tag_for_field(pb_ostream_t *stream, const pb_field_iter_t *field);
 
-/* Encode field header by manually specifing wire type. You need to use this
+/* Encode field header by manually specifying wire type. You need to use this
  * if you want to write out packed arrays from a callback field. */
 bool pb_encode_tag(pb_ostream_t *stream, pb_wire_type_t wiretype, uint32_t field_number);
 


### PR DESCRIPTION
There is a small typo in pb_encode.h, spm_headers/nanopb/pb_encode.h.

Should read `specifying` rather than `specifing`.

