### PR TITLE
Backport "Verify stream size before allocating string / bytes."

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1452,6 +1452,9 @@ static bool checkreturn pb_dec_bytes(pb_istream_t *stream, const pb_field_t *fie
 #ifndef PB_ENABLE_MALLOC
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
+        if (stream->bytes_left < size)
+            PB_RETURN_ERROR(stream, "end-of-stream");
+
         if (!allocate_field(stream, dest, alloc_size, 1))
             return false;
         bdest = *(pb_bytes_array_t**)dest;
@@ -1487,6 +1490,9 @@ static bool checkreturn pb_dec_string(pb_istream_t *stream, const pb_field_t *fi
 #ifndef PB_ENABLE_MALLOC
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
+        if (stream->bytes_left < size)
+            PB_RETURN_ERROR(stream, "end-of-stream");
+
         if (!allocate_field(stream, dest, alloc_size, 1))
             return false;
         dest = *(void**)dest;


### PR DESCRIPTION
The 0.4 branch contains commit 2519119babea ("Verify stream size before allocating string / bytes."):

    This stops ridicuously large mallocs from getting through
    on length-limited streams or buffers. Typically you should
    also override realloc() to limit allocation size yourself
    if dealing with untrusted data in pointer mode, but this
    at least limits the potential denial-of-service attacks.

Backport this patch in 0.3 maintenance branch in order to make fuzzing not crash as soon as the decoder tries to allocate a large buffer.

More precisely, while fuzzing a project using Nanopb 0.3.9.7 with libFuzzer, I got the following log:
```text
==16129== ERROR: libFuzzer: out-of-memory (malloc(3200220908))
   To change the out-of-memory limit use -rss_limit_mb=<N>

    #0 0x528101 in __sanitizer_print_stack_trace (/src/fuzz_my_parser+0x528101)
    #1 0x4711c8 in fuzzer::PrintStackTrace() (/src/fuzz_my_parser+0x4711c8)
    #2 0x4563c5 in fuzzer::Fuzzer::HandleMalloc(unsigned long) (/src/fuzz_my_parser+0x4563c5)
    #3 0x4562da in fuzzer::MallocHook(void const volatile*, unsigned long) (/src/fuzz_my_parser+0x4562da)
    #4 0x52e267 in __sanitizer::RunMallocHooks(void const*, unsigned long) (/src/fuzz_my_parser+0x52e267)
    #5 0x4a6e38 in __asan::Allocator::Allocate(unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType, bool) (/src/fuzz_my_parser+0x4a6e38)
    #6 0x4a71b5 in __asan::asan_realloc(void*, unsigned long, __sanitizer::BufferedStackTrace*) (/src/fuzz_my_parser+0x4a71b5)
    #7 0x51f79a in realloc (/src/fuzz_my_parser+0x51f79a)
    #8 0x558b8b in allocate_field /src/modules/nanopb/pb_decode.c:527:11
    #9 0x557e8b in pb_dec_bytes /src/modules/nanopb/pb_decode.c:1455:14
    #10 0x55670c in decode_pointer_field /src/modules/nanopb/pb_decode.c
    #11 0x5531c1 in decode_field /src/modules/nanopb/pb_decode.c:752:20
    #12 0x5524d0 in pb_decode_noinit /src/modules/nanopb/pb_decode.c:1022:14
    #13 0x5532a3 in pb_decode /src/modules/nanopb/pb_decode.c:1082:14
    #14 0x5585b4 in pb_dec_submessage /src/modules/nanopb/pb_decode.c:1521:18
    #15 0x55670c in decode_pointer_field /src/modules/nanopb/pb_decode.c
    #16 0x5531c1 in decode_field /src/modules/nanopb/pb_decode.c:752:20
    #17 0x5524d0 in pb_decode_noinit /src/modules/nanopb/pb_decode.c:1022:14
    #18 0x5532a3 in pb_decode /src/modules/nanopb/pb_decode.c:1082:14
...
```
This Pull Request fixes this issue.