### PR TITLE
Buildify BUILD and WORKSPACE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ examples/using_union_messages/decode
 examples/using_union_messages/encode
 generator/nanopb_pb2.pyc
 !generator-bin/**/*
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,17 +5,17 @@ exports_files(["LICENSE.txt"])
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-  name = "nanopb",
-  visibility = ["//visibility:public"],
-  hdrs = [
-    "pb.h",
-    "pb_common.h",
-    "pb_decode.h",
-    "pb_encode.h",
-  ],
-  srcs = [
-    "pb_common.c",
-    "pb_decode.c",
-    "pb_encode.c",
-  ],
+    name = "nanopb",
+    srcs = [
+        "pb_common.c",
+        "pb_decode.c",
+        "pb_encode.c",
+    ],
+    hdrs = [
+        "pb.h",
+        "pb_common.h",
+        "pb_decode.h",
+        "pb_encode.h",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,1 @@
-workspace(name="com_github_nanopb_nanopb")
+workspace(name = "com_github_nanopb_nanopb")


### PR DESCRIPTION
This formats both the BUILD.bazel and WORKSPACE files with the official Bazel formatter, called buildifier. Formatting separately will reduce noise in subsequent changes.