### PR TITLE
Add support for source comments in generated headers

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1608,10 +1608,10 @@ class ProtoFile:
                     field.type_name = mangle_field_typename(field.type_name)
 
             self.messages.append(Message(name, message, message_options))
-            for enum in message.enum_type:
+            for index, enum in enumerate(message.enum_type):
                 name = create_name(names + enum.name)
                 enum_options = get_nanopb_suboptions(enum, message_options, name)
-                self.enums.append(Enum(name, enum, enum_options))
+                self.enums.append(Enum(name, enum, enum_options, index, self.comment_locations))
 
         for names, extension in iterate_extensions(self.fdesc, flatten):
             name = create_name(names + extension.name)

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -372,6 +372,7 @@ class Enum(ProtoElement):
     def __str__(self):
         result = 'typedef enum _%s {\n' % self.names
 
+        enum_length = len(self.values)
         enum_values = []
         for index, (name, value) in enumerate(self.values):
             leading_comment, trailing_comment = self.get_comments_for_member(index)
@@ -379,7 +380,12 @@ class Enum(ProtoElement):
             if leading_comment:
                 enum_values.append(leading_comment)
 
-            enum_values.append("    %s = %d, %s" % (name, value, trailing_comment))
+            comma = ","
+            if index == enum_length - 1:
+                # last enum member should not end with a comma
+                comma = ""
+
+            enum_values.append("    %s = %d%s %s" % (name, value, comma, trailing_comment))
 
         result += '\n'.join(enum_values)
         result += '\n}'

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -291,8 +291,8 @@ class ProtoElement:
             For example, message == 4, enum == 5, service == 6
         index is the N-th occurance of the `path` in the proto file.
             For example, 4-th message in the proto file or 2-nd enum etc ...
-        comments is a pointer to SourceCodeInfo object containing all comment
-            information for each element & field in the original proto file.
+        comments is a dictionary mapping between element path & SourceCodeInfo.Location
+            (contains information about source comments).
         '''
         self.path = path
         self.index = index

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -284,7 +284,7 @@ ENUM_PATH = 5
 FIELD_PATH = 2
 
 
-class ProtoElement:
+class ProtoElement(object):
     def __init__(self, path, index, comments):
         '''
         path is a predefined value for each element type in proto file.
@@ -347,7 +347,7 @@ class Enum(ProtoElement):
         comments is a dictionary mapping between element path & SourceCodeInfo.Location
             (contains information about source comments)
         '''
-        super().__init__(ENUM_PATH, index, comments)
+        super(Enum, self).__init__(ENUM_PATH, index, comments)
 
         self.options = enum_options
         self.names = names
@@ -1121,7 +1121,7 @@ class OneOf(Field):
 
 class Message(ProtoElement):
     def __init__(self, names, desc, message_options, index, comments):
-        super().__init__(MESSAGE_PATH, index, comments)
+        super(Message, self).__init__(MESSAGE_PATH, index, comments)
         self.name = names
         self.fields = []
         self.oneofs = {}


### PR DESCRIPTION
Add support for proto file comments in generated headers.

Supports*:

- [X] Enum member comments (leading & trailing)
- [x] Enum comment (leading & trailing)
- [x] Message member comments (leading & trailing)
- [x] Message comment (leading & trailing)

\* Planning to implement all of the above

In order to enable this feature `protoc` must be called with `--include_source_info` flag. If that is not the case - these changes do not have any effect on generated headers.