### PR TITLE
[CMake] add build interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(nanopb_BUILD_RUNTIME)
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
         target_include_directories(protobuf-nanopb-static INTERFACE
           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         )
     endif()
 


### PR DESCRIPTION
If you add nanopb as a submodule. The headers won't be available correctly when building other projects in the superbuild.

Therefore I've added the `$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>`