### PR TITLE
Use CMAKE inbuilt mechanic to decide if protoc was found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ option(nanopb_BUILD_RUNTIME "Build the headers and libraries needed at runtime" 
 option(nanopb_BUILD_GENERATOR "Build the protoc plugin for code generation" ON)
 option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
 
-find_program(nanopb_PROTOC_PATH protoc REQUIRED)
+find_program(nanopb_PROTOC_PATH protoc)
+if(NOT EXISTS ${nanopb_PROTOC_PATH})
+    message(FATAL_ERROR "protoc compiler not found")
+endif()
 
 if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
     set(CMAKE_DEBUG_POSTFIX "d")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,7 @@ option(nanopb_BUILD_RUNTIME "Build the headers and libraries needed at runtime" 
 option(nanopb_BUILD_GENERATOR "Build the protoc plugin for code generation" ON)
 option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
 
-find_program(nanopb_PROTOC_PATH protoc)
-if(NOT EXISTS nanopb_PROTOC_PATH)
-    message(FATAL_ERROR "protoc compiler not found")
-endif()
+find_program(nanopb_PROTOC_PATH protoc REQUIRED)
 
 if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
     set(CMAKE_DEBUG_POSTFIX "d")


### PR DESCRIPTION
-The old way was wrong and would report errors when protoc was found. The correct way to do it manually would be to use if(NOT EXISTS ${nanopb_PROTOC_PATH})