### PR TITLE
Use the right path when checking for protoc path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(nanopb_BUILD_GENERATOR "Build the protoc plugin for code generation" ON)
 option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
 
 find_program(nanopb_PROTOC_PATH protoc)
-if(NOT EXISTS nanopb_PROTOC_PATH)
+if(NOT EXISTS "${nanopb_PROTOC_PATH}")
     message(FATAL_ERROR "protoc compiler not found")
 endif()
 


### PR DESCRIPTION
This is a small PR which addresses a bug introduced in #676 when checking for the `protoc` generator/compiler executable:

#676 started testing for file or directory existence via the integrated CMake function `if(EXISTS)`in the form `if(NOT EXISTS nanopb_PROTOC_PATH)`, however for the CMake to expand the variable, the use of `${}` needed, otherwise it will try to test for existence of literary the `nanopb_PROTOC_PATH`as a path.