### PR TITLE
Emit size_union only once, with guards

### DIFF
--- a/tests/regression/issue_693/SConscript
+++ b/tests/regression/issue_693/SConscript
@@ -1,0 +1,9 @@
+# Regression test for #693:
+# Duplicate declarations of size_unions with repeated fields inside a oneof
+
+Import("env")
+
+env.NanopbProto("other.proto")
+env.NanopbProto(["oneof.proto", "other.proto"])
+env.Object("oneof.pb.c")
+env.Object("test.c")

--- a/tests/regression/issue_693/oneof.proto
+++ b/tests/regression/issue_693/oneof.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+import "other.proto";
+
+message FirstOneof {}
+
+message Bar {
+  oneof content {
+    FirstOneof first = 1;
+    SecondOneof second = 2; // unknown size if no options are considered
+  }
+}
+
+message Foo {
+  AnotherList foo = 1;      // again, unknown size
+  Bar bar = 2;              // no duplicate size_union shall be generated anymore
+}
+
+

--- a/tests/regression/issue_693/other.proto
+++ b/tests/regression/issue_693/other.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message SecondOneof {
+    repeated int32 foo = 1;
+}
+
+message AnotherList {
+    repeated int32 bar = 1;
+}

--- a/tests/regression/issue_693/test.c
+++ b/tests/regression/issue_693/test.c
@@ -1,0 +1,7 @@
+/* This fakes the situation where other.proto was not found at generation time,
+   so size_union declarations are generated. */
+
+#define SecondOneof_size 88
+#define AnotherList_size 88
+
+#include "oneof.pb.h"


### PR DESCRIPTION
This Pull-Request fixes issue #692, where the same sizeof_union may get generated twice. This change only emits a sizeof_union once per file.