### PR TITLE
Remove dependency on Python distutils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,6 @@ if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
 endif()
 
 find_package(Python REQUIRED COMPONENTS Interpreter)
-execute_process(
-    COMMAND ${Python_EXECUTABLE} -c
-        "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
-    OUTPUT_VARIABLE PYTHON_INSTDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
 
 if(nanopb_BUILD_GENERATOR)
     set(generator_protos nanopb)
@@ -62,13 +56,13 @@ if(nanopb_BUILD_GENERATOR)
         install(
             FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
                   ${generator_proto_file}
-            DESTINATION ${PYTHON_INSTDIR}/proto/
+            DESTINATION ${Python_SITELIB}/proto/
         )
     endforeach()
 endif()
 
 install(FILES generator/proto/_utils.py
-        DESTINATION ${PYTHON_INSTDIR}/proto/)
+        DESTINATION ${Python_SITELIB}/proto/)
 
 if(WIN32)
     install(

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -18,7 +18,7 @@ from functools import reduce
 
 try:
     # Add some dummy imports to keep packaging tools happy.
-    import google, distutils.util # bbfreeze seems to need these
+    import google # bbfreeze seems to need these
     import pkg_resources # pyinstaller / protobuf 2.5 seem to need these
     import proto.nanopb_pb2 as nanopb_pb2 # pyinstaller seems to need this
     import pkg_resources.py2_warn


### PR DESCRIPTION
As of Python 3.10, the `distutils` module is deprecated ([PEP 632](https://www.python.org/dev/peps/pep-0632/)), and importing it triggers a warning.

This PR removes all references to `distutils` from nanopb.