### PR TITLE
Use memcpy instead of iterating on buf_read/write

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -67,14 +67,12 @@ typedef struct {
 
 static bool checkreturn buf_read(pb_istream_t *stream, pb_byte_t *buf, size_t count)
 {
-    size_t i;
     const pb_byte_t *source = (const pb_byte_t*)stream->state;
     stream->state = (pb_byte_t*)stream->state + count;
     
     if (buf != NULL)
     {
-        for (i = 0; i < count; i++)
-            buf[i] = source[i];
+        memcpy(buf, source, count * sizeof(pb_byte_t));
     }
     
     return true;

--- a/pb_encode.c
+++ b/pb_encode.c
@@ -51,12 +51,10 @@ static bool checkreturn pb_enc_fixed_length_bytes(pb_ostream_t *stream, const pb
 
 static bool checkreturn buf_write(pb_ostream_t *stream, const pb_byte_t *buf, size_t count)
 {
-    size_t i;
     pb_byte_t *dest = (pb_byte_t*)stream->state;
     stream->state = dest + count;
     
-    for (i = 0; i < count; i++)
-        dest[i] = buf[i];
+    memcpy(dest, buf, count * sizeof(pb_byte_t));
     
     return true;
 }


### PR DESCRIPTION
**Description:**
Enabling `PB_BUFFER_ONLY` should speed up execution ([ref](https://github.com/nanopb/nanopb/blob/1d43d109af32ef2b083ba0312259e2e06407f023/docs/reference.md))
When the flag is set, the `buf_read`/`buf_write` functions are used to copy data from/to a stream respectively.
Using iteration is much inferior to `memcpy`.
In my case, switching to `memcpy` increased the performance by a factor of 8.