### PR TITLE
fix for custom 'realloc' with a context #775

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,6 +11,7 @@ The following options can be specified in one of two ways:
 includes nanopb headers.
 
 * `PB_ENABLE_MALLOC`: Enable dynamic allocation support in the decoder.
+* `PB_ENABLE_MALLOC_CONTEXT`: Enable dynamic allocation support in the decoder using a function pointer in istream instead of library function realloc()
 * `PB_MAX_REQUIRED_FIELDS`: Maximum number of proto2 `required` fields to check for presence. Default value is 64. Compiler warning will tell if you need this.
 * `PB_FIELD_32BIT`: Add support for field tag numbers over 65535, fields larger than 64 kiB and arrays larger than 65535 entries. Compiler warning will tell if you need this.
 * `PB_NO_ERRMSG`: Disable error message support to save code size. Only error information is the `true`/`false` return value.

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -12,9 +12,11 @@ CSRC += $(NANOPB_DIR)/pb_encode.c  # The nanopb encoder
 CSRC += $(NANOPB_DIR)/pb_decode.c  # The nanopb decoder
 CSRC += $(NANOPB_DIR)/pb_common.c  # The nanopb common parts
 
+# this is an example - rebuild it every time
+.PHONY: simple
 # Build rule for the main program
 simple: $(CSRC)
-	$(CC) $(CFLAGS) -osimple $(CSRC)
+	$(CC) -DDEBUG_MALLOC -DPB_ENABLE_MALLOC_CONTEXT $(CFLAGS) -osimple $(CSRC)
 
 # Build rule for the protocol
 simple.pb.c: simple.proto

--- a/extra/pb_syshdr.h
+++ b/extra/pb_syshdr.h
@@ -62,7 +62,7 @@ typedef int bool;
 #endif
 
 /* stdlib.h subset */
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #else

--- a/pb.h
+++ b/pb.h
@@ -87,7 +87,7 @@
 #include <string.h>
 #include <limits.h>
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 #include <stdlib.h>
 #endif
 #endif
@@ -470,7 +470,7 @@ struct pb_extension_s {
 
 /* Memory allocation functions to use. You can define pb_realloc and
  * pb_free to custom functions if you want. */
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 #   ifndef pb_realloc
 #       define pb_realloc(ptr, size) realloc(ptr, size)
 #   endif

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -42,7 +42,7 @@ static bool checkreturn pb_dec_fixed_length_bytes(pb_istream_t *stream, const pb
 static bool checkreturn pb_skip_varint(pb_istream_t *stream);
 static bool checkreturn pb_skip_string(pb_istream_t *stream);
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 static bool checkreturn allocate_field(pb_istream_t *stream, void *pData, size_t data_size, size_t array_size);
 static void initialize_pointer_field(void *pItem, pb_field_iter_t *field);
 static bool checkreturn pb_release_union_field(pb_istream_t *stream, pb_field_iter_t *field);
@@ -156,6 +156,9 @@ pb_istream_t pb_istream_from_buffer(const pb_byte_t *buf, size_t msglen)
 #ifndef PB_NO_ERRMSG
     stream.errmsg = NULL;
 #endif
+    #ifdef PB_ENABLE_MALLOC_CONTEXT
+    stream.realloc = NULL;
+    #endif
     return stream;
 }
 
@@ -549,7 +552,7 @@ static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t
     }
 }
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 /* Allocate storage for the field and store the pointer at iter->pData.
  * array_size is the number of entries to reserve in an array.
  * Zero size is not allowed, use pb_free() for releasing.
@@ -591,7 +594,15 @@ static bool checkreturn allocate_field(pb_istream_t *stream, void *pData, size_t
     /* Allocate new or expand previous allocation */
     /* Note: on failure the old pointer will remain in the structure,
      * the message must be freed by caller also on error return. */
+    #ifdef PB_ENABLE_MALLOC_CONTEXT
+    if (stream->realloc == NULL) {
+      ptr = pb_realloc(ptr, array_size * data_size);
+    } else {
+      ptr = stream->realloc(stream,ptr, array_size * data_size);
+    }
+    #else
     ptr = pb_realloc(ptr, array_size * data_size);
+    #endif
     if (ptr == NULL)
         PB_RETURN_ERROR(stream, "realloc failed");
     
@@ -618,7 +629,7 @@ static void initialize_pointer_field(void *pItem, pb_field_iter_t *field)
 
 static bool checkreturn decode_pointer_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field)
 {
-#ifndef PB_ENABLE_MALLOC
+#if ! ( defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT) )
     PB_UNUSED(wire_type);
     PB_UNUSED(field);
     PB_RETURN_ERROR(stream, "no malloc support");
@@ -792,7 +803,7 @@ static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type
 
 static bool checkreturn decode_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field)
 {
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
     /* When decoding an oneof field, check if there is old data that must be
      * released first. */
     if (PB_HTYPE(field->type) == PB_HTYPE_ONEOF)
@@ -1166,7 +1177,7 @@ bool checkreturn pb_decode_ex(pb_istream_t *stream, const pb_msgdesc_t *fields, 
         return false;
     }
     
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
     if (!status)
         pb_release(fields, dest_struct);
 #endif
@@ -1180,7 +1191,7 @@ bool checkreturn pb_decode(pb_istream_t *stream, const pb_msgdesc_t *fields, voi
 
     status = pb_decode_inner(stream, fields, dest_struct, 0);
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
     if (!status)
         pb_release(fields, dest_struct);
 #endif
@@ -1188,7 +1199,7 @@ bool checkreturn pb_decode(pb_istream_t *stream, const pb_msgdesc_t *fields, voi
     return status;
 }
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 /* Given an oneof field, if there has already been a field inside this oneof,
  * release it before overwriting with a different one. */
 static bool pb_release_union_field(pb_istream_t *stream, pb_field_iter_t *field)
@@ -1500,7 +1511,7 @@ static bool checkreturn pb_dec_bytes(pb_istream_t *stream, const pb_field_iter_t
     
     if (PB_ATYPE(field->type) == PB_ATYPE_POINTER)
     {
-#ifndef PB_ENABLE_MALLOC
+#if ! ( defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT) )
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
         if (stream->bytes_left < size)
@@ -1542,7 +1553,7 @@ static bool checkreturn pb_dec_string(pb_istream_t *stream, const pb_field_iter_
 
     if (PB_ATYPE(field->type) == PB_ATYPE_POINTER)
     {
-#ifndef PB_ENABLE_MALLOC
+#if ! ( defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT) )
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
         if (stream->bytes_left < size)

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -601,7 +601,7 @@ static bool checkreturn allocate_field(pb_istream_t *stream, void *pData, size_t
       ptr = stream->realloc(stream,ptr, array_size * data_size);
     }
     #else
-    ptr = pb_realloc(ptr, array_size * data_size);
+      ptr = pb_realloc(ptr, array_size * data_size);
     #endif
     if (ptr == NULL)
         PB_RETURN_ERROR(stream, "realloc failed");

--- a/pb_decode.h
+++ b/pb_decode.h
@@ -43,6 +43,10 @@ struct pb_istream_s
 #ifndef PB_NO_ERRMSG
     const char *errmsg;
 #endif
+  #ifdef PB_ENABLE_MALLOC_CONTEXT
+  /* Note: we do not need a corresponding free() here, because we can (and do) call realloc with size==0 to free memory. */
+  void *(*realloc)(pb_istream_t *stream,void *ptr, size_t size);
+  #endif
 };
 
 #ifndef PB_NO_ERRMSG
@@ -107,7 +111,7 @@ bool pb_decode_ex(pb_istream_t *stream, const pb_msgdesc_t *fields, void *dest_s
 #define pb_decode_delimited_noinit(s,f,d) pb_decode_ex(s,f,d, PB_DECODE_DELIMITED | PB_DECODE_NOINIT)
 #define pb_decode_nullterminated(s,f,d) pb_decode_ex(s,f,d, PB_DECODE_NULLTERMINATED)
 
-#ifdef PB_ENABLE_MALLOC
+#if defined(PB_ENABLE_MALLOC) || defined(PB_ENABLE_MALLOC_CONTEXT)
 /* Release any allocated pointer fields. If you use dynamic allocation, you should
  * call this for any successfully decoded message when you are done with it. If
  * pb_decode() returns with an error, the message is already released.

--- a/tests/common/SConscript
+++ b/tests/common/SConscript
@@ -46,3 +46,13 @@ malloc_env.Depends("$NANOPB/pb.h", ["malloc_wrappers_syshdr.h", "malloc_wrappers
 
 Export("malloc_env")
 
+custom_malloc_env = malloc_env.Clone()
+# custom_malloc_env.Append(CFLAGS = malloc_env['CORECFLAGS'])
+custom_malloc_env.Object("pb_decode_with_custom_malloc.o", "$NANOPB/pb_decode.c")
+custom_malloc_env.Object("pb_encode_with_custom_malloc.o", "$NANOPB/pb_encode.c")
+custom_malloc_env.Object("pb_common_with_custom_malloc.o", "$NANOPB/pb_common.c")
+custom_malloc_env.Append(CPPDEFINES = {'PB_ENABLE_MALLOC_CONTEXT': 1,
+                                'MALLOC_DEBUG': 1,
+				})
+
+Export("custom_malloc_env")

--- a/tests/custom_realloc/SConscript
+++ b/tests/custom_realloc/SConscript
@@ -1,0 +1,39 @@
+# Encode the AllTypes message using pointers for all fields, and verify the
+# output against the normal AllTypes test case.
+
+Import("env", "custom_malloc_env")
+
+c = Copy("$TARGET", "$SOURCE")
+env.Command("alltypes.proto", "#alltypes/alltypes.proto", c)
+
+env.NanopbProto(["alltypes", "alltypes.options"])
+enc = custom_malloc_env.Program(["encode_alltypes_pointer.c",
+                          "alltypes.pb.c",
+                          "$COMMON/pb_encode_with_custom_malloc.o",
+                          "$COMMON/pb_common_with_custom_malloc.o",
+                          "$COMMON/malloc_wrappers.o"])
+dec = custom_malloc_env.Program(["decode_alltypes_pointer.c",
+                          "alltypes.pb.c",
+                          "$COMMON/pb_decode_with_custom_malloc.o",
+                          "$COMMON/pb_common_with_custom_malloc.o",
+                          "$COMMON/malloc_wrappers.o"])
+
+# Encode and compare results to non-pointer alltypes test case
+env.RunTest(enc)
+env.Compare(["encode_alltypes_pointer.output", "$BUILD/alltypes/encode_alltypes.output"])
+
+# Decode (under valgrind if available)
+kwargs = {}
+if env.get("VALGRIND"):
+    kwargs['COMMAND'] = env['VALGRIND']
+    kwargs['ARGS'] = ["-q", "--error-exitcode=99", dec[0].abspath]
+
+env.RunTest("decode_alltypes.output", [dec, "encode_alltypes_pointer.output"], **kwargs)
+
+# Do the same thing with the optional fields present
+env.RunTest("optionals.output", enc, ARGS = ['1'])
+env.Compare(["optionals.output", "$BUILD/alltypes/optionals.output"])
+
+kwargs['ARGS'] = kwargs.get('ARGS', []) + ['1']
+env.RunTest("optionals.decout", [dec, "optionals.output"], **kwargs)
+

--- a/tests/custom_realloc/alltypes.options
+++ b/tests/custom_realloc/alltypes.options
@@ -1,0 +1,11 @@
+# Generate all fields as pointers.
+* type:FT_POINTER
+*.static_msg type:FT_STATIC
+SubMessage.substuff1 type:FT_STATIC max_size:8
+*.*fbytes fixed_length:true max_size:4
+*.*farray fixed_count:true max_count:5
+*.*farray2 fixed_count:true max_count:3
+IntSizes.*int8 int_size:IS_8
+IntSizes.*int16 int_size:IS_16
+DescriptorSize8 descriptorsize:DS_8
+

--- a/tests/custom_realloc/decode_alltypes_pointer.c
+++ b/tests/custom_realloc/decode_alltypes_pointer.c
@@ -1,0 +1,236 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pb_decode.h>
+#include "alltypes.pb.h"
+#include "test_helpers.h"
+#include "unittests.h"
+
+static volatile uint32_t counter;
+void *my_custom_realloc(pb_istream_t *stream,void *ptr, size_t size) {
+  counter++; 
+  /* just delegate to the stdlib */
+  return pb_realloc(ptr,size);
+}
+/* This function is called once from main(), it handles
+   the decoding and checks the fields. */
+bool check_alltypes(pb_istream_t *stream, int mode)
+{
+    int status = 0;
+    AllTypes alltypes;
+    
+    /* Fill with garbage to better detect initialization errors */
+    memset(&alltypes, 0xAA, sizeof(alltypes));
+    alltypes.extensions = 0;
+    
+    if (!pb_decode(stream, AllTypes_fields, &alltypes))
+        return false;
+    
+    TEST(alltypes.req_int32     && *alltypes.req_int32         == -1001);
+    TEST(alltypes.req_int64     && *alltypes.req_int64         == -1002);
+    TEST(alltypes.req_uint32    && *alltypes.req_uint32        == 1003);
+    TEST(alltypes.req_uint64    && *alltypes.req_uint64        == 1004);
+    TEST(alltypes.req_sint32    && *alltypes.req_sint32        == -1005);
+    TEST(alltypes.req_sint64    && *alltypes.req_sint64        == -1006);
+    TEST(alltypes.req_bool      && *alltypes.req_bool          == true);
+    
+    TEST(alltypes.req_fixed32   && *alltypes.req_fixed32       == 1008);
+    TEST(alltypes.req_sfixed32  && *alltypes.req_sfixed32      == -1009);
+    TEST(alltypes.req_float     && *alltypes.req_float         == 1010.0f);
+    
+    TEST(alltypes.req_fixed64   && *alltypes.req_fixed64       == 1011);
+    TEST(alltypes.req_sfixed64  && *alltypes.req_sfixed64      == -1012);
+    TEST(alltypes.req_double    && *alltypes.req_double        == 1013.0f);
+    
+    TEST(alltypes.req_string    && strcmp(alltypes.req_string, "1014") == 0);
+    TEST(alltypes.req_bytes     && alltypes.req_bytes->size == 4);
+    TEST(alltypes.req_bytes     && memcmp(&alltypes.req_bytes->bytes, "1015", 4) == 0);
+    TEST(alltypes.req_submsg    && strcmp(alltypes.req_submsg->substuff1, "1016") == 0);
+    TEST(alltypes.req_submsg    && alltypes.req_submsg->substuff2
+                                && *alltypes.req_submsg->substuff2 == 1016);
+    TEST(alltypes.req_enum      && *alltypes.req_enum == MyEnum_Truth);
+    TEST(alltypes.req_fbytes    && memcmp(alltypes.req_fbytes, "1019", 4) == 0);
+
+    TEST(alltypes.rep_int32_count == 5 && alltypes.rep_int32[4] == -2001 && alltypes.rep_int32[0] == 0);
+    TEST(alltypes.rep_int64_count == 5 && alltypes.rep_int64[4] == -2002 && alltypes.rep_int64[0] == 0);
+    TEST(alltypes.rep_uint32_count == 5 && alltypes.rep_uint32[4] == 2003 && alltypes.rep_uint32[0] == 0);
+    TEST(alltypes.rep_uint64_count == 5 && alltypes.rep_uint64[4] == 2004 && alltypes.rep_uint64[0] == 0);
+    TEST(alltypes.rep_sint32_count == 5 && alltypes.rep_sint32[4] == -2005 && alltypes.rep_sint32[0] == 0);
+    TEST(alltypes.rep_sint64_count == 5 && alltypes.rep_sint64[4] == -2006 && alltypes.rep_sint64[0] == 0);
+    TEST(alltypes.rep_bool_count == 5 && alltypes.rep_bool[4] == true && alltypes.rep_bool[0] == false);
+    
+    TEST(alltypes.rep_fixed32_count == 5 && alltypes.rep_fixed32[4] == 2008 && alltypes.rep_fixed32[0] == 0);
+    TEST(alltypes.rep_sfixed32_count == 5 && alltypes.rep_sfixed32[4] == -2009 && alltypes.rep_sfixed32[0] == 0);
+    TEST(alltypes.rep_float_count == 5 && alltypes.rep_float[4] == 2010.0f && alltypes.rep_float[0] == 0.0f);
+    
+    TEST(alltypes.rep_fixed64_count == 5 && alltypes.rep_fixed64[4] == 2011 && alltypes.rep_fixed64[0] == 0);
+    TEST(alltypes.rep_sfixed64_count == 5 && alltypes.rep_sfixed64[4] == -2012 && alltypes.rep_sfixed64[0] == 0);
+    TEST(alltypes.rep_double_count == 5 && alltypes.rep_double[4] == 2013.0 && alltypes.rep_double[0] == 0.0);
+    
+    TEST(alltypes.rep_string_count == 5 && strcmp(alltypes.rep_string[4], "2014") == 0 && alltypes.rep_string[0][0] == '\0');
+    TEST(alltypes.rep_bytes_count == 5 && alltypes.rep_bytes[4]->size == 4 && alltypes.rep_bytes[0]->size == 0);
+    TEST(memcmp(&alltypes.rep_bytes[4]->bytes, "2015", 4) == 0);
+
+    TEST(alltypes.rep_submsg_count == 5);
+    TEST(strcmp(alltypes.rep_submsg[4].substuff1, "2016") == 0 && alltypes.rep_submsg[0].substuff1[0] == '\0');
+    TEST(*alltypes.rep_submsg[4].substuff2 == 2016 && *alltypes.rep_submsg[0].substuff2 == 0);
+    TEST(*alltypes.rep_submsg[4].substuff3 == 2016 && alltypes.rep_submsg[0].substuff3 == NULL);
+    
+    TEST(alltypes.rep_enum_count == 5 && alltypes.rep_enum[4] == MyEnum_Truth && alltypes.rep_enum[0] == MyEnum_Zero);
+    TEST(alltypes.rep_emptymsg_count == 5);
+    TEST(alltypes.rep_fbytes_count == 5);
+    TEST(alltypes.rep_fbytes[0][0] == 0 && alltypes.rep_fbytes[0][3] == 0);
+    TEST(memcmp(alltypes.rep_fbytes[4], "2019", 4) == 0);
+    TEST(alltypes.rep_farray && (*alltypes.rep_farray)[0] == 0 && (*alltypes.rep_farray)[4] == 2040);
+    TEST(alltypes.rep_farray2 && (*alltypes.rep_farray2)[0] == 0 && (*alltypes.rep_farray2)[2] == 2095);
+
+    if (mode == 0)
+    {
+        /* Expect that optional values are not present */
+        TEST(alltypes.opt_int32         == NULL);
+        TEST(alltypes.opt_int64         == NULL);
+        TEST(alltypes.opt_uint32        == NULL);
+        TEST(alltypes.opt_uint64        == NULL);
+        TEST(alltypes.opt_sint32        == NULL);
+        TEST(alltypes.opt_sint64        == NULL);
+        TEST(alltypes.opt_bool          == NULL);
+        
+        TEST(alltypes.opt_fixed32       == NULL);
+        TEST(alltypes.opt_sfixed32      == NULL);
+        TEST(alltypes.opt_float         == NULL);
+        TEST(alltypes.opt_fixed64       == NULL);
+        TEST(alltypes.opt_sfixed64      == NULL);
+        TEST(alltypes.opt_double        == NULL);
+        
+        TEST(alltypes.opt_string        == NULL);
+        TEST(alltypes.opt_bytes         == NULL);
+        TEST(alltypes.opt_submsg        == NULL);
+        TEST(alltypes.opt_enum          == NULL);
+        TEST(alltypes.opt_fbytes        == NULL);
+
+        TEST(alltypes.which_oneof       == 0);
+
+        TEST(alltypes.opt_non_zero_based_enum == NULL);
+    }
+    else
+    {
+        /* Expect filled-in values */
+        TEST(alltypes.opt_int32 && *alltypes.opt_int32      == 3041);
+        TEST(alltypes.opt_int64 && *alltypes.opt_int64      == 3042);
+        TEST(alltypes.opt_uint32 && *alltypes.opt_uint32    == 3043);
+        TEST(alltypes.opt_uint64 && *alltypes.opt_uint64    == 3044);
+        TEST(alltypes.opt_sint32 && *alltypes.opt_sint32    == 3045);
+        TEST(alltypes.opt_sint64 && *alltypes.opt_sint64    == 3046);
+        TEST(alltypes.opt_bool && *alltypes.opt_bool        == true);
+        
+        TEST(alltypes.opt_fixed32 && *alltypes.opt_fixed32  == 3048);
+        TEST(alltypes.opt_sfixed32 && *alltypes.opt_sfixed32== 3049);
+        TEST(alltypes.opt_float && *alltypes.opt_float      == 3050.0f);
+        TEST(alltypes.opt_fixed64 && *alltypes.opt_fixed64  == 3051);
+        TEST(alltypes.opt_sfixed64 && *alltypes.opt_sfixed64== 3052);
+        TEST(alltypes.opt_double && *alltypes.opt_double    == 3053.0);
+        
+        TEST(alltypes.opt_string && strcmp(alltypes.opt_string, "3054") == 0);
+        TEST(alltypes.opt_bytes && alltypes.opt_bytes->size == 4);
+        TEST(alltypes.opt_bytes && memcmp(&alltypes.opt_bytes->bytes, "3055", 4) == 0);
+        TEST(alltypes.opt_submsg && strcmp(alltypes.opt_submsg->substuff1, "3056") == 0);
+        TEST(alltypes.opt_submsg && *alltypes.opt_submsg->substuff2 == 3056);
+        TEST(alltypes.opt_enum && *alltypes.opt_enum == MyEnum_Truth);
+        TEST(alltypes.opt_emptymsg);
+        TEST(alltypes.opt_fbytes && memcmp(alltypes.opt_fbytes, "3059", 4) == 0);
+
+        TEST(alltypes.which_oneof == AllTypes_oneof_msg1_tag);
+        TEST(alltypes.oneof.oneof_msg1 && strcmp(alltypes.oneof.oneof_msg1->substuff1, "4059") == 0);
+        TEST(alltypes.oneof.oneof_msg1->substuff2 && *alltypes.oneof.oneof_msg1->substuff2 == 4059);
+
+        TEST(alltypes.opt_non_zero_based_enum && *alltypes.opt_non_zero_based_enum == NonZeroBasedEnum_Three);
+    }
+    
+    TEST(alltypes.req_limits->int32_min && *alltypes.req_limits->int32_min   == INT32_MIN);
+    TEST(alltypes.req_limits->int32_max && *alltypes.req_limits->int32_max   == INT32_MAX);
+    TEST(alltypes.req_limits->uint32_min && *alltypes.req_limits->uint32_min == 0);
+    TEST(alltypes.req_limits->uint32_max && *alltypes.req_limits->uint32_max == UINT32_MAX);
+    TEST(alltypes.req_limits->int64_min && *alltypes.req_limits->int64_min   == INT64_MIN);
+    TEST(alltypes.req_limits->int64_max && *alltypes.req_limits->int64_max   == INT64_MAX);
+    TEST(alltypes.req_limits->uint64_min && *alltypes.req_limits->uint64_min == 0);
+    TEST(alltypes.req_limits->uint64_max && *alltypes.req_limits->uint64_max == UINT64_MAX);
+    TEST(alltypes.req_limits->enum_min && *alltypes.req_limits->enum_min     == HugeEnum_Negative);
+    TEST(alltypes.req_limits->enum_max && *alltypes.req_limits->enum_max     == HugeEnum_Positive);
+    TEST(alltypes.req_limits->largetag && *alltypes.req_limits->largetag   == 1001);
+
+    TEST(alltypes.req_ds8);
+    TEST(alltypes.req_ds8->first && *alltypes.req_ds8->first == 9991);
+    TEST(alltypes.req_ds8->first && *alltypes.req_ds8->second == 9992);
+    
+    TEST(alltypes.req_intsizes);
+    TEST(*alltypes.req_intsizes->req_int8 == -128);
+    TEST(*alltypes.req_intsizes->req_uint8 == 255);
+    TEST(*alltypes.req_intsizes->req_sint8 == -128);
+    TEST(*alltypes.req_intsizes->req_int16 == -32768);
+    TEST(*alltypes.req_intsizes->req_uint16 == 65535);
+    TEST(*alltypes.req_intsizes->req_sint16 == -32768);
+
+    TEST(alltypes.end && *alltypes.end == 1099);
+
+    pb_release(AllTypes_fields, &alltypes);
+
+    return status == 0;
+}
+
+int main(int argc, char **argv)
+{
+    uint8_t buffer[1024];
+    size_t count;
+    pb_istream_t stream;
+    
+    /* Whether to expect the optional values or the default values. */
+    int mode = (argc > 1) ? atoi(argv[1]) : 0;
+    
+    /* Read the data into buffer */
+    SET_BINARY_MODE(stdin);
+    count = fread(buffer, 1, sizeof(buffer), stdin);
+
+    /* Test #1 - test if a custom realloc is called and valgrind remains happy */
+    /* Construct a pb_istream_t for reading from the buffer */
+    stream = pb_istream_from_buffer(buffer, count);
+    counter=0; /* init so we can see if it does what we expect it to */
+    stream.realloc=&my_custom_realloc;
+    /* Decode and verify the message */
+    if (!check_alltypes(&stream, mode))
+    {
+        fprintf(stderr, "Test #1 failed: %s\n", PB_GET_ERROR(&stream));
+        return 1;
+    }
+
+    if (counter == 0)
+    {
+        fprintf(stderr, "Test #1 failed, a custom realloc was set, but not called\n");
+        return 1;
+    }
+
+
+    /* Test #2 - test if custom realloc is NULL, that it is NOT called */
+    
+    /* Construct a pb_istream_t for reading from the buffer */
+    stream = pb_istream_from_buffer(buffer, count);
+    counter=0; /* init so we can see if it does what we expect it to */
+    stream.realloc=NULL; /* default really */
+    /* Decode and verify the message */
+    if (!check_alltypes(&stream, mode))
+    {
+        fprintf(stderr, "Test #2 failed: %s\n", PB_GET_ERROR(&stream));
+        return 1;
+    }
+
+    /*
+      this can only happen if there is a bug and some dangling pointer to our custom realloc that should not be there
+      someone, some day might think to cache the realloc pointer from a previous call. We catch this here
+    */
+    if (counter != 0)
+    {
+      fprintf(stderr, "Test #2 failed, a custom realloc was set to NULL, but counter was incremented (value %i) (likely a BUG in the test itself)\n",counter);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/custom_realloc/encode_alltypes_pointer.c
+++ b/tests/custom_realloc/encode_alltypes_pointer.c
@@ -1,0 +1,227 @@
+/* Attempts to test all the datatypes supported by ProtoBuf.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pb_encode.h>
+#include "alltypes.pb.h"
+#include "test_helpers.h"
+
+int main(int argc, char **argv)
+{
+    int mode = (argc > 1) ? atoi(argv[1]) : 0;
+    
+    /* Values for required fields */
+    int32_t     req_int32         = -1001;
+    int64_t     req_int64         = -1002;
+    uint32_t    req_uint32        = 1003;
+    uint64_t    req_uint64        = 1004;
+    int32_t     req_sint32        = -1005;
+    int64_t     req_sint64        = -1006;
+    bool        req_bool          = true;
+    uint32_t    req_fixed32       = 1008;
+    int32_t     req_sfixed32      = -1009;
+    float       req_float         = 1010.0f;
+    uint64_t    req_fixed64       = 1011;
+    int64_t     req_sfixed64      = -1012;
+    double      req_double        = 1013.0;
+    char*       req_string        = "1014";
+    PB_BYTES_ARRAY_T(4) req_bytes = {4, {'1', '0', '1', '5'}};
+    static int32_t req_substuff   = 1016;
+    SubMessage  req_submsg        = {"1016", &req_substuff};
+    MyEnum      req_enum          = MyEnum_Truth;
+    EmptyMessage req_emptymsg     = {0};
+    pb_byte_t   req_fbytes[4]     = {'1', '0', '1', '9'};
+    
+    int32_t     end               = 1099;
+
+    /* Values for repeated fields */
+    int32_t     rep_int32[5]      = {0, 0, 0, 0, -2001};
+    int64_t     rep_int64[5]      = {0, 0, 0, 0, -2002};
+    uint32_t    rep_uint32[5]     = {0, 0, 0, 0, 2003};
+    uint64_t    rep_uint64[5]     = {0, 0, 0, 0, 2004};
+    int32_t     rep_sint32[5]     = {0, 0, 0, 0, -2005};
+    int64_t     rep_sint64[5]     = {0, 0, 0, 0, -2006};
+    bool        rep_bool[5]       = {false, false, false, false, true};
+    uint32_t    rep_fixed32[5]    = {0, 0, 0, 0, 2008};
+    int32_t     rep_sfixed32[5]   = {0, 0, 0, 0, -2009};
+    float       rep_float[5]      = {0, 0, 0, 0, 2010.0f};
+    uint64_t    rep_fixed64[5]    = {0, 0, 0, 0, 2011};
+    int64_t     rep_sfixed64[5]   = {0, 0, 0, 0, -2012};
+    double      rep_double[5]     = {0, 0, 0, 0, 2013.0f};
+    char*       rep_string[5]     = {"", "", "", "", "2014"};
+    static PB_BYTES_ARRAY_T(4) rep_bytes_4 = {4, {'2', '0', '1', '5'}};
+    pb_bytes_array_t *rep_bytes[5]= {NULL, NULL, NULL, NULL, (pb_bytes_array_t*)&rep_bytes_4};
+    static int32_t rep_sub2zero   = 0;
+    static int32_t rep_substuff2  = 2016;
+    static uint32_t rep_substuff3 = 2016;
+    SubMessage  rep_submsg[5]     = {{"", &rep_sub2zero},
+                                     {"", &rep_sub2zero},
+                                     {"", &rep_sub2zero},
+                                     {"", &rep_sub2zero},
+                                     {"2016", &rep_substuff2, &rep_substuff3}};
+    MyEnum      rep_enum[5]       = {0, 0, 0, 0, MyEnum_Truth};
+    EmptyMessage rep_emptymsg[5]  = {{0}, {0}, {0}, {0}, {0}};
+    pb_byte_t   rep_fbytes[5][4]  = {{0}, {0}, {0}, {0}, {'2', '0', '1', '9'}};
+    int32_t     rep_farray[5]     = {0, 0, 0, 0, 2040};
+    uint32_t    rep_farray2[3]    = {0, 0, 2095};
+
+    /* Values for optional fields */
+    int32_t     opt_int32         = 3041;
+    int64_t     opt_int64         = 3042;
+    uint32_t    opt_uint32        = 3043;
+    uint64_t    opt_uint64        = 3044;
+    int32_t     opt_sint32        = 3045;
+    int64_t     opt_sint64        = 3046;
+    bool        opt_bool          = true;
+    uint32_t    opt_fixed32       = 3048;
+    int32_t     opt_sfixed32      = 3049;
+    float       opt_float         = 3050.0f;
+    uint64_t    opt_fixed64       = 3051;
+    int64_t     opt_sfixed64      = 3052;
+    double      opt_double        = 3053.0;
+    char*       opt_string        = "3054";
+    PB_BYTES_ARRAY_T(4) opt_bytes = {4, {'3', '0', '5', '5'}};
+    static int32_t opt_substuff   = 3056;
+    SubMessage  opt_submsg        = {"3056", &opt_substuff};
+    MyEnum      opt_enum          = MyEnum_Truth;
+    EmptyMessage opt_emptymsg     = {0};
+    pb_byte_t   opt_fbytes[4]     = {'3', '0', '5', '9'};
+
+    static int32_t oneof_substuff = 4059;
+    SubMessage  oneof_msg1        = {"4059", &oneof_substuff};
+
+    NonZeroBasedEnum opt_non_zero_based_enum = NonZeroBasedEnum_Three;
+
+    /* Values for the Limits message. */
+    static int32_t  int32_min  = INT32_MIN;
+    static int32_t  int32_max  = INT32_MAX;
+    static uint32_t uint32_min = 0;
+    static uint32_t uint32_max = UINT32_MAX;
+    static int64_t  int64_min  = INT64_MIN;
+    static int64_t  int64_max  = INT64_MAX;
+    static uint64_t uint64_min = 0;
+    static uint64_t uint64_max = UINT64_MAX;
+    static HugeEnum enum_min   = HugeEnum_Negative;
+    static HugeEnum enum_max   = HugeEnum_Positive;
+    static int32_t largetag    = 1001;
+    Limits req_limits = {&int32_min,    &int32_max,
+                         &uint32_min,   &uint32_max,
+                         &int64_min,    &int64_max,
+                         &uint64_min,   &uint64_max,
+                         &enum_min,     &enum_max,
+                         &largetag};
+
+    /* Values for DescriptorSize8 message. */
+    static int32_t first = 9991;
+    static int32_t second = 9992;
+    DescriptorSize8 req_ds8 = {&first, &second};
+
+    /* Values for IntSizes message. */
+    static int8_t req_int8 = -128;
+    static uint8_t req_uint8 = 255;
+    static int8_t req_sint8 = -128;
+    static int16_t req_int16 = -32768;
+    static uint16_t req_uint16 = 65535;
+    static int16_t req_sint16 = -32768;
+    IntSizes req_intsizes = {&req_int8, &req_uint8, &req_sint8,
+                             &req_int16, &req_uint16, &req_sint16};
+
+    /* Initialize the message struct with pointers to the fields. */
+    AllTypes alltypes = {0};
+
+    alltypes.req_int32         = &req_int32;
+    alltypes.req_int64         = &req_int64;
+    alltypes.req_uint32        = &req_uint32;
+    alltypes.req_uint64        = &req_uint64;
+    alltypes.req_sint32        = &req_sint32;
+    alltypes.req_sint64        = &req_sint64;
+    alltypes.req_bool          = &req_bool;
+    alltypes.req_fixed32       = &req_fixed32;
+    alltypes.req_sfixed32      = &req_sfixed32;
+    alltypes.req_float         = &req_float;
+    alltypes.req_fixed64       = &req_fixed64;
+    alltypes.req_sfixed64      = &req_sfixed64;
+    alltypes.req_double        = &req_double;
+    alltypes.req_string        = req_string;
+    alltypes.req_bytes         = (pb_bytes_array_t*)&req_bytes;
+    alltypes.req_submsg        = &req_submsg;
+    alltypes.req_enum          = &req_enum;
+    alltypes.req_emptymsg      = &req_emptymsg;
+    alltypes.req_fbytes        = &req_fbytes;
+    alltypes.req_limits        = &req_limits;
+    alltypes.req_ds8           = &req_ds8;
+    alltypes.req_intsizes      = &req_intsizes;
+    
+    alltypes.rep_int32_count    = 5; alltypes.rep_int32     = rep_int32;
+    alltypes.rep_int64_count    = 5; alltypes.rep_int64     = rep_int64;
+    alltypes.rep_uint32_count   = 5; alltypes.rep_uint32    = rep_uint32;
+    alltypes.rep_uint64_count   = 5; alltypes.rep_uint64    = rep_uint64;
+    alltypes.rep_sint32_count   = 5; alltypes.rep_sint32    = rep_sint32;
+    alltypes.rep_sint64_count   = 5; alltypes.rep_sint64    = rep_sint64;
+    alltypes.rep_bool_count     = 5; alltypes.rep_bool      = rep_bool;
+    alltypes.rep_fixed32_count  = 5; alltypes.rep_fixed32   = rep_fixed32;
+    alltypes.rep_sfixed32_count = 5; alltypes.rep_sfixed32  = rep_sfixed32;
+    alltypes.rep_float_count    = 5; alltypes.rep_float     = rep_float;
+    alltypes.rep_fixed64_count  = 5; alltypes.rep_fixed64   = rep_fixed64;
+    alltypes.rep_sfixed64_count = 5; alltypes.rep_sfixed64  = rep_sfixed64;
+    alltypes.rep_double_count   = 5; alltypes.rep_double    = rep_double;
+    alltypes.rep_string_count   = 5; alltypes.rep_string    = rep_string;
+    alltypes.rep_bytes_count    = 5; alltypes.rep_bytes     = rep_bytes;
+    alltypes.rep_submsg_count   = 5; alltypes.rep_submsg    = rep_submsg;
+    alltypes.rep_enum_count     = 5; alltypes.rep_enum      = rep_enum;
+    alltypes.rep_emptymsg_count = 5; alltypes.rep_emptymsg  = rep_emptymsg;
+    alltypes.rep_fbytes_count   = 5; alltypes.rep_fbytes    = rep_fbytes;
+    alltypes.rep_farray = &rep_farray;
+    alltypes.rep_farray2 = &rep_farray2;
+    
+    if (mode != 0)
+    {
+        /* Fill in values for optional fields */
+        alltypes.opt_int32         = &opt_int32;
+        alltypes.opt_int64         = &opt_int64;
+        alltypes.opt_uint32        = &opt_uint32;
+        alltypes.opt_uint64        = &opt_uint64;
+        alltypes.opt_sint32        = &opt_sint32;
+        alltypes.opt_sint64        = &opt_sint64;
+        alltypes.opt_bool          = &opt_bool;
+        alltypes.opt_fixed32       = &opt_fixed32;
+        alltypes.opt_sfixed32      = &opt_sfixed32;
+        alltypes.opt_float         = &opt_float;
+        alltypes.opt_fixed64       = &opt_fixed64;
+        alltypes.opt_sfixed64      = &opt_sfixed64;
+        alltypes.opt_double        = &opt_double;
+        alltypes.opt_string        = opt_string;
+        alltypes.opt_bytes         = (pb_bytes_array_t*)&opt_bytes;
+        alltypes.opt_submsg        = &opt_submsg;
+        alltypes.opt_enum          = &opt_enum;
+        alltypes.opt_emptymsg      = &opt_emptymsg;
+        alltypes.opt_fbytes        = &opt_fbytes;
+
+        alltypes.which_oneof = AllTypes_oneof_msg1_tag;
+        alltypes.oneof.oneof_msg1 = &oneof_msg1;
+
+        alltypes.opt_non_zero_based_enum = &opt_non_zero_based_enum;
+    }
+    
+    alltypes.end = &end;
+    
+    {
+        uint8_t buffer[4096];
+        pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+        
+        /* Now encode it and check if we succeeded. */
+        if (pb_encode(&stream, AllTypes_fields, &alltypes))
+        {
+            SET_BINARY_MODE(stdout);
+            fwrite(buffer, 1, stream.bytes_written, stdout);
+            return 0; /* Success */
+        }
+        else
+        {
+            fprintf(stderr, "Encoding failed: %s\n", PB_GET_ERROR(&stream));
+            return 1; /* Failure */
+        }
+    }
+}


### PR DESCRIPTION
implements code and tests as discussed here https://github.com/nanopb/nanopb/issues/775
also patches example 'simple' to compile unconditionally (.PHONY) (because it seems useful for an example to reuse latest and it compiles in less than a second anyways) and with malloc support.

