### PR TITLE
Generate MSGTYPE definitions for UENUM fields

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1422,7 +1422,7 @@ class Message(ProtoElement):
             result += '#define %s_DEFAULT NULL\n' % Globals.naming_style.define_name(self.name)
 
         for field in sorted_fields:
-            if field.pbtype in ['MESSAGE', 'MSG_W_CB', "UENUM"]:
+            if field.pbtype in ['MESSAGE', 'MSG_W_CB']:
                 if field.rules == 'ONEOF':
                     result += "#define %s_%s_%s_MSGTYPE %s\n" % (
                         Globals.naming_style.type_name(self.name),
@@ -1432,6 +1432,21 @@ class Message(ProtoElement):
                     )
                 else:
                     result += "#define %s_%s_MSGTYPE %s\n" % (
+                        Globals.naming_style.type_name(self.name),
+                        Globals.naming_style.var_name(field.name),
+                        Globals.naming_style.type_name(field.ctype)
+                    )
+
+            if field.pbtype in ['ENUM', "UENUM"]:
+                if field.rules == 'ONEOF':
+                    result += "#define %s_%s_%s_ENUMTYPE %s\n" % (
+                        Globals.naming_style.type_name(self.name),
+                        Globals.naming_style.var_name(field.union_name),
+                        Globals.naming_style.var_name(field.name),
+                        Globals.naming_style.type_name(field.ctype)
+                    )
+                else:
+                    result += "#define %s_%s_ENUMTYPE %s\n" % (
                         Globals.naming_style.type_name(self.name),
                         Globals.naming_style.var_name(field.name),
                         Globals.naming_style.type_name(field.ctype)

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1422,7 +1422,7 @@ class Message(ProtoElement):
             result += '#define %s_DEFAULT NULL\n' % Globals.naming_style.define_name(self.name)
 
         for field in sorted_fields:
-            if field.pbtype in ['MESSAGE', 'MSG_W_CB']:
+            if field.pbtype in ['MESSAGE', 'MSG_W_CB', "UENUM"]:
                 if field.rules == 'ONEOF':
                     result += "#define %s_%s_%s_MSGTYPE %s\n" % (
                         Globals.naming_style.type_name(self.name),


### PR DESCRIPTION
This causes MSGTYPE macros to generate for UENUM fields so that the enum types can be inferred by macro expansions. 

Without this there seems to be no way to deduce the type name of an enum in a protobuf message field from the preprocessor.

This allows for macro constructions that automatically call the ENUMTYPE_name() functions generated by the enum_to_string feature.