### PR TITLE
Remove extraneous single quotes around value of --library-include-format option

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -20,6 +20,7 @@ isotes <isotes@gmail.com>
 Maxim Khitrov <max@mxcrypt.com>
 Yaniv Mordekhay <yanivmo@users.noreply.github.com>
 Ming Zhao <mzhao@luminatewireless.com>
+Randy Zhang <randyzhg95@gmail.com>
 Google, Inc.
 Tom Roeder <tmroeder@google.com>
 Piotr Sikora <piotrsikora@google.com>

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,7 +49,7 @@ py_binary(
 proto_plugin(
     name = "nanopb_plugin",
     options = [
-        "--library-include-format='#include\"%s\"'",
+        "--library-include-format=#include\"%s\"",
     ],
     outputs = [
         "{protopath}.pb.h",


### PR DESCRIPTION
Remove extraneous single quotes around value of `--library-include-format`
option for the Bazel nanopb_plugin.

This bug only seems to surface when passing additional options to
`cc_nanopb_proto_library`, via either `extra_protoc_args` or `options`.

Example error message at compile time:
```
error: expected identifier or '(' before '\x622e6822'
    6 | '#include"pb.h"'
      | ^~~~~~~~~~~~~~~~
```