### PR TITLE
PlatformIO generator fix spaces in path

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2503,6 +2503,12 @@ def main_plugin():
     import os.path
     options.options_path.append(os.path.dirname(request.file_to_generate[0]))
 
+    # FIXME: Hack for https://github.com/nanopb/nanopb/pull/808
+    new_options_path = []
+    for p in options.options_path:
+        new_options_path.append(p.strip('"\''))
+    options.options_path = new_options_path
+
     # Process any include files first, in order to have them
     # available as dependencies
     other_files = {}

--- a/generator/platformio_generator.py
+++ b/generator/platformio_generator.py
@@ -56,9 +56,9 @@ else:
     protoc_generator = os.path.join(nanopb_root, 'generator', 'protoc')
 
     nanopb_options = ""
-    nanopb_options += f" --nanopb_out={generated_src_dir}"
+    nanopb_options += f' --nanopb_out="{generated_src_dir}"'
     for opt in nanopb_plugin_options:
-        nanopb_options += (" --nanopb_opt=" + opt)
+        nanopb_options += f' --nanopb_opt="{opt}"'
 
     try:
         os.makedirs(generated_src_dir)
@@ -70,6 +70,8 @@ else:
     except FileExistsError:
         pass
 
+    # nanopb_options += f' --nanopb_opt="--verbose"'
+
     # Collect include dirs based on
     proto_include_dirs = set()
     for proto_file in protos_files:
@@ -78,8 +80,8 @@ else:
         proto_include_dirs.add(proto_dir)
 
     for proto_include_dir in proto_include_dirs:
-        nanopb_options += (" --proto_path=" + proto_include_dir)
-        nanopb_options += (" --nanopb_opt=-I" + proto_include_dir)
+        nanopb_options += f' --proto_path="{proto_include_dir}"'
+        nanopb_options += f' --nanopb_opt=\'-I"{proto_include_dir}"\''
 
     for proto_file in protos_files:
         proto_file_abs = os.path.join(project_dir, proto_file)
@@ -132,7 +134,7 @@ else:
             print(f"[nanopb] Skipping '{proto_file}' ({options_info})")
         else:
             print(f"[nanopb] Processing '{proto_file}' ({options_info})")
-            cmd = protoc_generator + " " + nanopb_options + " " + proto_file_basename
+            cmd = f'"{protoc_generator}" {nanopb_options} {proto_file_basename}'
             result = env.Execute(cmd)
             if result != 0:
                 print(f"[nanopb] ERROR: ({result}) processing cmd: '{cmd}'")


### PR DESCRIPTION
This is replacement for the https://github.com/nanopb/nanopb/pull/808.

But it is not ready, because it has hack in `nanopb_generator.py`.

Actually I did not find any suitable solution to pass path with string to the `nanopb_generator.py`

I tried 

```
 nanopb_options += f' --nanopb_opt=\'-I"{proto_include_dir}"\''
```

Resulting command is:

```sh
"/Users/pavel/projects/nanopb/generator/../generator/protoc"  
--nanopb_out="/Users/pavel/projects/nanopb/examples/platformio test/.pio/build/pio_with_options/nanopb/generated-src" 
--nanopb_opt="--error-on-unmatched" 
--nanopb_opt="--verbose" --proto_path="/Users/pavel/projects/nanopb/examples/platformio test/proto" 
--nanopb_opt='-I"/Users/pavel/projects/nanopb/examples/platformio test/proto"' pio_with_options.proto
```

But protoc passes internal quotes inside value, and I got next  `nanopb_generator.py`:

**args:**
```
['--error-on-unmatched', '--verbose', '-I"/Users/pavel/projects/nanopb/examples/platformio test/proto"']
```

**options.options_path:**
```
['"/Users/pavel/projects/nanopb/examples/platformio test/proto"']
```

So, it has quotes inside and It doesn not work.

@PetteriAimonen lets continue discuss here if you have any ideas to make it more nice.
