### PR TITLE
Allow including inside of extern C

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -902,10 +902,13 @@ struct pb_extension_s {
 #define PB_INLINE_CONSTEXPR PB_CONSTEXPR
 #endif  // __cplusplus >= 201703L
 
+extern "C++"
+{
 namespace nanopb {
 // Each type will be partially specialized by the generator.
 template <typename GenMessageT> struct MessageDescriptor;
 }  // namespace nanopb
+}
 #endif  /* __cplusplus */
 
 #endif


### PR DESCRIPTION
I have production code in C and I'm using C++ test framework and that caused some linkage problems with nanopb. This patch fixed my problem and hopefully some others too.