### PR TITLE
PlatformIO: Added `includeDir` to `build` section of the library.json.

### DIFF
--- a/library.json
+++ b/library.json
@@ -27,6 +27,7 @@
   },
   "build": {
     "extraScript": "generator/platformio_generator.py",
+    "includeDir": "",
     "srcDir": "",
     "srcFilter": [
       "+<*.c>"


### PR DESCRIPTION
This should allow LDF to find dependency in default (chain) mode without specifying it explicitly.

ref #818