### PR TITLE
pb.h: Fix build on MSVC

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -170,6 +170,9 @@ extern "C" {
 #    if defined(__ICCARM__)
        /* IAR has static_assert keyword but no _Static_assert */
 #      define PB_STATIC_ASSERT(COND,MSG) static_assert(COND,#MSG);
+#    elif defined(_MSC_VER)
+       /* MSVC has static_assert keyword but no _Static_assert */
+#      define PB_STATIC_ASSERT(COND,MSG) static_assert(COND,#MSG);
 #    elif defined(PB_C99_STATIC_ASSERT)
        /* Classic negative-size-array static assert mechanism */
 #      define PB_STATIC_ASSERT(COND,MSG) typedef char PB_STATIC_ASSERT_MSG(MSG, __LINE__, __COUNTER__)[(COND)?1:-1];


### PR DESCRIPTION
Apparently MSVC lacks C-style static asserts, but it does have C++ style static asserts even in C code. Monado has used nanopb with this patch for some time and it seems to work fine.