### PR TITLE
Fix PYTHON_INSTDIR resolve in Docker containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 find_package(Python REQUIRED COMPONENTS Interpreter)
 execute_process(
     COMMAND ${Python_EXECUTABLE} -c
-        "import os.path, sys, sysconfig; print(os.path.relpath(sysconfig.get_path('purelib'), start=sys.prefix))"
+        "import os.path, sys, sysconfig; from pathlib import Path;  print(Path(sysconfig.get_path('purelib')).resolve())"
     OUTPUT_VARIABLE PYTHON_INSTDIR
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
Hi everyone,
I've found an issue while creating a Docker container (using as a base image _crops/yocto:ubuntu-20.04-base_ ) meant to use nanopb code generator.
It would always resolve such variable into:
**/usr/local/local/lib/python3.10/dist-packages/proto/nanopb_pb2.py**

As you can see, the _/local/local_ should be resolved into _/local/_ only. To fix this, i've made a very small fix on this branch.

Out of curiosity, the current approach does work in the following myself-tested environments:
- Windows
- Yocto (both native and target)

NB: This is my first time opening a pull request on such project. Please be kind!
Thank you!