### PR TITLE
Add ability to specify size of generated enums

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,6 +9,16 @@ document.
 Nanopb-0.4.7 (2022-xx-xx)
 -------------------------
 
+### Add int_size option to enum fields
+
+**Rationale:** The `packed_enum` option does not work with MSVC due to `#pragma pack` not supporting enums with MSVC. To workaround this, enum sizes can be specified with the new `int_size` option. Note that this is only supported when generating C++.
+
+**Changes:** The `int_size` option can be specified for enums.
+
+**Required actions:** Any users concerned about the size of the generated C++ enums and are setting the int_size of enums via a wildcard (e.g. `MyMessage.*  int_size=IS_8`) will need to instead set the `int_size` option for individual fields.
+
+**Error indications:** The size of generated C++ enums has changed.
+
 ### Updated include path order in FindNanopb.cmake
 
 **Changes:** The include path passed to `protoc` by the CMake rules was updated.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -50,7 +50,7 @@ The full set of available options is defined in [nanopb.proto](https://github.co
 * `fixed_length`: Generate `bytes` fields with a constant length defined by `max_size`. A separate `.size` field will then not be generated.
 * `fixed_count`: Generate arrays with constant length defined by `max_count`.
 * `package`: Package name that applies only for nanopb generator. Defaults to name defined by `package` keyword in .proto file, which applies for all languages.
-* `int_size`: Override the integer type of a field. For example, specify `int_size = IS_8` to convert `int32` from protocol definition into `int8_t` in the structure.
+* `int_size`: Override the integer type of a field. For example, specify `int_size = IS_8` to convert `int32` from protocol definition into `int8_t` in the structure. When used with enum types, the size of the generated enum can be specified (C++ only)
 
 These options can be defined for the .proto files before they are
 converted using the nanopb-generator.py. There are three ways to define

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -99,7 +99,11 @@ datatypes = {
     FieldD.TYPE_UINT32:     ('uint32_t', 'UINT32',      5,  4),
     FieldD.TYPE_UINT64:     ('uint64_t', 'UINT64',     10,  8),
 
-    # Integer size override options
+    # Integer size override option
+    (FieldD.TYPE_ENUM,    nanopb_pb2.IS_8):   ('uint8_t', 'ENUM',  4,  1),
+    (FieldD.TYPE_ENUM,   nanopb_pb2.IS_16):   ('uint16_t', 'ENUM',  4,  2),
+    (FieldD.TYPE_ENUM,   nanopb_pb2.IS_32):   ('uint32_t', 'ENUM',  4,  4),
+    (FieldD.TYPE_ENUM,   nanopb_pb2.IS_64):   ('uint64_t', 'ENUM',  4,  8),
     (FieldD.TYPE_INT32,   nanopb_pb2.IS_8):   ('int8_t',   'INT32', 10,  1),
     (FieldD.TYPE_INT32,  nanopb_pb2.IS_16):   ('int16_t',  'INT32', 10,  2),
     (FieldD.TYPE_INT32,  nanopb_pb2.IS_32):   ('int32_t',  'INT32', 10,  4),
@@ -431,7 +435,18 @@ class Enum(ProtoElement):
         if leading_comment:
             result = '%s\n' % leading_comment
 
-        result += 'typedef enum %s {' % Globals.naming_style.enum_name(self.names)
+        result += 'typedef enum %s' % Globals.naming_style.enum_name(self.names)
+
+        # Override the enum size if user wants to use smaller integers
+        if (FieldD.TYPE_ENUM, self.options.int_size) in datatypes:
+            self.ctype, self.pbtype, self.enc_size, self.data_item_size = datatypes[(FieldD.TYPE_ENUM, self.options.int_size)]
+            result += '\n#ifdef __cplusplus\n'
+            result += ' : ' + self.ctype + '\n'
+            result += '#endif\n'
+            result += '{'
+        else:
+            result += ' {'
+
         if trailing_comment:
             result += " " + trailing_comment
 

--- a/tests/enum_sizes/SConscript
+++ b/tests/enum_sizes/SConscript
@@ -5,8 +5,10 @@ Import('env')
 env.NanopbProto('enumsizes')
 
 p = env.Program(["enumsizes_unittests.c",
+                 "enumsizes_intsize_unittests.cc",
                  "enumsizes.pb.c",
                  "$COMMON/pb_encode.o",
                  "$COMMON/pb_decode.o",
                  "$COMMON/pb_common.o"])
 env.RunTest(p)
+

--- a/tests/enum_sizes/enumsizes.proto
+++ b/tests/enum_sizes/enumsizes.proto
@@ -58,6 +58,41 @@ enum PackedInt16 {
     PI16_MAX = 32767;
 }
 
+enum IntSizeInt8
+{
+    option (nanopb_enumopt).int_size = IS_8;
+    I8_A = 0;
+    I8_B = 2;
+    I8_C = 3;
+}
+
+
+enum IntSizeInt16
+{
+    option (nanopb_enumopt).int_size = IS_16;
+    I16_A = 0;
+    I16_B = 2;
+    I16_C = 3;
+}
+
+
+enum IntSizeInt32
+{
+    option (nanopb_enumopt).int_size = IS_32;
+    I32_A = 0;
+    I32_B = 2;
+    I32_C = 3;
+}
+
+
+enum IntSizeInt64
+{
+    option (nanopb_enumopt).int_size = IS_64;
+    I64_A = 0;
+    I64_B = 2;
+    I64_C = 3;
+}
+
 /* Protobuf supports enums up to 32 bits.
  * The 32 bit case is covered by HugeEnum in the alltypes test.
  */

--- a/tests/enum_sizes/enumsizes_intsize_unittests.cc
+++ b/tests/enum_sizes/enumsizes_intsize_unittests.cc
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "enumsizes.pb.h"
+#include "unittests.h"
+
+extern "C" int TestIntSize() {
+  int status = 0;
+
+  TEST(sizeof(IntSizeInt8) == sizeof(uint8_t));
+  TEST(sizeof(IntSizeInt16) == sizeof(uint16_t));
+  TEST(sizeof(IntSizeInt32) == sizeof(uint32_t));
+  TEST(sizeof(IntSizeInt64) == sizeof(uint64_t));
+
+  if (status != 0) fprintf(stdout, "\n\nSome tests FAILED!\n");
+
+  return status;
+}

--- a/tests/enum_sizes/enumsizes_intsize_unittests.h
+++ b/tests/enum_sizes/enumsizes_intsize_unittests.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int TestIntSize();

--- a/tests/enum_sizes/enumsizes_unittests.c
+++ b/tests/enum_sizes/enumsizes_unittests.c
@@ -4,6 +4,7 @@
 #include <pb_encode.h>
 #include "unittests.h"
 #include "enumsizes.pb.h"
+#include "enumsizes_intsize_unittests.h"
 
 int main()
 {
@@ -64,6 +65,8 @@ int main()
         TEST(msg1.i16_min == (int)msg2.i16_min);
         TEST(msg1.i16_max == (int)msg2.i16_max);
     }
+
+    status |= TestIntSize();
 
     if (status != 0)
         fprintf(stdout, "\n\nSome tests FAILED!\n");


### PR DESCRIPTION
While the [`packed_enum`](https://github.com/nanopb/nanopb/blob/91fb301dabb83beb28f2ad266be6aaee7a1a4e00/generator/proto/nanopb.proto#L76) option exists, this does not work when using the MSVC compiler. 

This PR adds the ability to specify the size of the generated enums (this works for C++ only)