### PR TITLE
ref |> Modified The generated code uses utf-8 encoding by default.

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2499,7 +2499,7 @@ def main_cli():
             if dirname and not os.path.exists(dirname):
                 os.makedirs(dirname)
 
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write(data)
 
 def main_plugin():


### PR DESCRIPTION
Avoid garbled code generated when annotating proto in Chinese or other languages.