### PR TITLE
Make stream state available for message field callbacks also during message size calculation

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -726,7 +726,8 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *
     pb_ostream_t substream = PB_OSTREAM_SIZING;
     size_t size;
     bool status;
-    
+
+    substream.state = stream->state;
     if (!pb_encode(&substream, fields, src_struct))
     {
 #ifndef PB_NO_ERRMSG


### PR DESCRIPTION
This is more of a question rather than puill request.

I have simple message with arbitrarily big payload that I want to handle procedurally.
I would also like to use message field callbacks.

Unless I'm mistaken, I need to set option `callback_datatype` just to get message callbacks prototype generated even though I won't be using those pointers.

```
message Test {
  required bytes payload = 1 [(nanopb).callback_datatype = "void*"];
}
```

After implementing `Test_callback` everything works as expected except my payload size is not known inside the callback so I need to pass it as global variable at the moment.
ostream->state is only set on 2nd callback invocation (in encode mode).
Is it intentional, in ex. to tell user that it's "size calculation phase"? (so that one could just manually update bytes_written or do dummy pb_write(... NULL, size) instead of doing more sophisticated encoding)
If so, is there any way to pass user data than global variable?
One could also of course just encode message manually using encoding primitives functions, but I would prefer to use message field callbacks as much as possible (manual set callbacks are ..meh)