### PR TITLE
Fix first path passed to protoc

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -144,7 +144,7 @@ function(NANOPB_GENERATE_CPP SRCS HDRS)
       list(APPEND _nanopb_include_path "-I${ABS_PATH}")
     endforeach()
   else()
-    set(_nanopb_include_path "-I${CMAKE_CURRENT_SOURCE_DIR}")
+    list(APPEND _nanopb_include_path "-I${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 
   if(DEFINED NANOPB_IMPORT_DIRS)


### PR DESCRIPTION
Fix relative path passed to protoc when using RELPATH but NANOPB_GENERATE_CPP_APPEND_PATH not set. In this case the path provided by RELPATH should be passed to protoc first instead of the current source directory.

This was working before and broke with 8cc860c.