### PR TITLE
Add missing source and data files to `protoc-gen-nanopb`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,9 +37,16 @@ copy_file(
 
 py_binary(
     name = "protoc-gen-nanopb",
-    srcs = [
-        "generator/nanopb_generator.py",
+    srcs = glob([
+        "generator/**/*.py",
+    ]) + [
         ":protoc-gen-nanopb.py",
+    ],
+    data = glob([
+        "generator/**/*.proto",
+    ]),
+    imports = [
+        "generator",
     ],
     deps = [
         requirement("grpcio-tools"),


### PR DESCRIPTION
This should fix https://github.com/nanopb/nanopb/issues/890 by adding all the required source and data files needed for the `protoc` generator.