### PR TITLE
Support stripping package names with a dependent proto file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ end in an error, the test cases were successful.
 
 Note: Mac OS X by default aliases 'clang' as 'gcc', while not actually
 supporting the same command line options as gcc does. To run tests on
-Mac OS X, use: `scons CC=clang CXX=clang`. Same way can be used to run
+Mac OS X, use: `scons CC=clang CXX=clang++`. Same way can be used to run
 tests with different compilers on any platform.
 
 For embedded platforms, there is currently support for running the tests

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -512,7 +512,7 @@ class Enum(ProtoElement):
             # Define the long names always so that enum value references
             # from other files work properly.
             for i, x in enumerate(self.values):
-                result += '#define %s %s\n' % (self.value_longnames[i], x[0])
+                result += '#define %s %s\n' % (Globals.naming_style.define_name(self.value_longnames[i]), Globals.naming_style.enum_entry(x[0]))
 
         if self.options.enum_to_string:
             result += 'const char *%s(%s v);\n' % (

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -481,16 +481,32 @@ class Enum(ProtoElement):
     def auxiliary_defines(self):
         # sort the enum by value
         sorted_values = sorted(self.values, key = lambda x: (x[1], x[0]))
-        result  = '#define %s %s\n' % (
-            Globals.naming_style.define_name('_%s_MIN' % self.names),
+
+        unmangledName = self.protofile.manglenames.unmangle(self.names)
+        identifier = Globals.naming_style.define_name('_%s_MIN' % self.names)
+        result = '#define %s %s\n' % (
+            identifier,
             Globals.naming_style.enum_entry(sorted_values[0][0]))
+        if unmangledName:
+            unmangledIdentifier = Globals.naming_style.define_name('_%s_MIN' % unmangledName)
+            self.protofile.manglenames.reverse_name_mapping[identifier] = unmangledIdentifier
+
+        identifier = Globals.naming_style.define_name('_%s_MAX' % self.names)
         result += '#define %s %s\n' % (
-            Globals.naming_style.define_name('_%s_MAX' % self.names),
+            identifier,
             Globals.naming_style.enum_entry(sorted_values[-1][0]))
+        if unmangledName:
+            unmangledIdentifier = Globals.naming_style.define_name('_%s_MAX' % unmangledName)
+            self.protofile.manglenames.reverse_name_mapping[identifier] = unmangledIdentifier
+
+        identifier = Globals.naming_style.define_name('_%s_ARRAYSIZE' % self.names)
         result += '#define %s ((%s)(%s+1))\n' % (
-            Globals.naming_style.define_name('_%s_ARRAYSIZE' % self.names),
+            identifier,
             Globals.naming_style.type_name(self.names),
             Globals.naming_style.enum_entry(sorted_values[-1][0]))
+        if unmangledName:
+            unmangledIdentifier = Globals.naming_style.define_name('_%s_ARRAYSIZE' % unmangledName)
+            self.protofile.manglenames.reverse_name_mapping[identifier] = unmangledIdentifier
 
         if not self.options.long_names:
             # Define the long names always so that enum value references

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1963,9 +1963,17 @@ class ProtoFile:
             for msg in self.messages:
                 identifier = Globals.naming_style.define_name('%s_init_default' % msg.name)
                 yield '#define %-40s %s\n' % (identifier, msg.get_initializer(False))
+                unmangledName = self.manglenames.unmangle(msg.name)
+                if unmangledName:
+                    unmangledIdentifier = Globals.naming_style.define_name('%s_init_default' % unmangledName)
+                    self.manglenames.reverse_name_mapping[identifier] = unmangledIdentifier
             for msg in self.messages:
                 identifier = Globals.naming_style.define_name('%s_init_zero' % msg.name)
                 yield '#define %-40s %s\n' % (identifier, msg.get_initializer(True))
+                unmangledName = self.manglenames.unmangle(msg.name)
+                if unmangledName:
+                    unmangledIdentifier = Globals.naming_style.define_name('%s_init_zero' % unmangledName)
+                    self.manglenames.reverse_name_mapping[identifier] = unmangledIdentifier
             yield '\n'
 
             yield '/* Field tags (for use in manual encoding/decoding) */\n'

--- a/tests/proto3_optional/SConscript
+++ b/tests/proto3_optional/SConscript
@@ -6,8 +6,8 @@ import re
 
 version = None
 if 'PROTOC_VERSION' in env:
-    match = re.search('([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
-    version = (int(match.group(1)), int(match.group(2)))
+    match = re.search('(?:([0-9]+).)?([0-9]+).([0-9]+)', env['PROTOC_VERSION'])
+    version = (int(match.group(1) or 3), int(match.group(2)), int(match.group(3)))
 
 # Oneof is supported by protoc >= 3.12.0
 if env.GetOption('clean') or (version and (version[0] > 3 or (version[0] == 3 and version[1] >= 12))):

--- a/tests/typename_mangling/SConscript
+++ b/tests/typename_mangling/SConscript
@@ -14,6 +14,14 @@ env.Command("strip_package.proto", "with_package.proto", Copy("$TARGET", "$SOURC
 env.NanopbProto(["strip_package", "strip_package.options"])
 env.Program(["test_strip_package.c", "strip_package.pb.c", '$COMMON/pb_common.o'])
 
+env.Command("strip_package_a.options", "with_package.options", set_mangling("M_STRIP_PACKAGE"))
+env.Command("strip_package_b.options", "with_package.options", set_mangling("M_STRIP_PACKAGE"))
+env.Command("strip_package_a.proto", "with_package_a.proto", Copy("$TARGET", "$SOURCE"))
+env.Command("strip_package_b.proto", "with_package_b.proto", Copy("$TARGET", "$SOURCE"))
+env.NanopbProto(["strip_package_a", "strip_package_a.options"])
+env.NanopbProto(["strip_package_b", "strip_package_b.options"])
+env.Program(["test_strip_package_dependencies.c", "strip_package_a.pb.c", "strip_package_b.pb.c", '$COMMON/pb_common.o'])
+
 env.Command("flatten.options", "with_package.options", set_mangling("M_FLATTEN"))
 env.Command("flatten.proto", "with_package.proto", Copy("$TARGET", "$SOURCE"))
 env.NanopbProto(["flatten", "flatten.options"])

--- a/tests/typename_mangling/test_strip_package_dependencies.c
+++ b/tests/typename_mangling/test_strip_package_dependencies.c
@@ -1,0 +1,27 @@
+/*
+ * Tests if expected names are generated when M_STRIP_PACKAGE is used.
+ */
+
+#include <stdio.h>
+#include "unittests.h"
+#include "strip_package_b.pb.h"
+
+int main()
+{
+    MessageA msgA1 = package_a_MessageA_init_default;
+    package_a_MessageA msgA2 = MessageA_init_default;
+
+    MessageB msgB1 = package_b_MessageB_init_zero;
+    package_b_MessageB msgB2 = MessageB_init_zero;
+
+    package_a_EnumA e1 = EnumA_VALUE_A_0;
+    EnumA e2 = EnumA_VALUE_A_1;
+    e2 = _package_a_EnumA_MIN;
+    e2 = _EnumA_MIN;
+    e2 = _package_a_EnumA_MAX;
+    e2 = _EnumA_MAX;
+    e2 = _package_a_EnumA_ARRAYSIZE;
+    e2 = _EnumA_ARRAYSIZE;
+
+    return msgA1.enum_a_field + msgA2.enum_a_field + msgB1.nested_enum + msgB2.nested_enum + e1 + e2; /* marks variables as used */
+}

--- a/tests/typename_mangling/with_package_a.proto
+++ b/tests/typename_mangling/with_package_a.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package package.a;
+
+enum EnumA {
+  VALUE_A_0 = 0;
+  VALUE_A_1 = 1;
+  VALUE_A_2 = 2;
+}
+
+message MessageA {
+  EnumA enum_a_field = 1;
+}

--- a/tests/typename_mangling/with_package_b.proto
+++ b/tests/typename_mangling/with_package_b.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "strip_package_a.proto";
+
+package package.b;
+
+message MessageB {
+  package.a.EnumA nested_enum = 1;
+  package.a.MessageA nested_message = 2;
+}


### PR DESCRIPTION
Fixes #865

When proto file _B_ defines `MessageB` containing a field with type `MessageA` that is defined in proto file _A_ which is using name mangling, stripping package names in this case, the `_init_zero` and `_init_default` `#defines` in file _B_ still use the long names from file _A_ and fail to compile. Similarly, the `_MIN`, `_MAX`, and `_ARRAYSIZE` `#defines` only use shorter identifiers.

This solution tries to follow the existing behavior of creating a `#define` mapping from long names to short names when using name mangling. It checks if the identifier is mangled, and populates the `MangleNames.reverse_name_mapping` dictionary with both the identifiers, ensuring both conform to the naming style. I included a test for this behavior.

This also includes two other bug fixes, but I'm happy to split them out into separate PRs if desired:
1. Update readme instruction for testing on Mac.
2. Ensure long enum names conform to the naming style when using short enum names.