### PR TITLE
Fix Command Generator Location of Simple Example 

### DIFF
--- a/examples/simple/README.txt
+++ b/examples/simple/README.txt
@@ -20,7 +20,7 @@ run it with the command: ./simple
 On other platforms, you first have to compile the protocol definition using
 the following command::
 
-  ../../generator-bin/protoc --nanopb_out=. simple.proto
+  ../../generator/protoc --nanopb_out=. simple.proto
 
 After that, add the following five files to your project and compile:
 


### PR DESCRIPTION
This pull request addresses the issue of the command generator location. 

The change involves updating the command used for code generation from `../../generator-bin/protoc --nanopb_out=. simple.proto` to ` ../../generator/protoc --nanopb_out=. simple.proto` .
