### PR TITLE
Add support for .options files in bazel rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -90,6 +90,24 @@ cc_nanopb_proto_library(
     visibility = ["//visibility:private"],
 )
 
+proto_library(
+    name = "all_types_proto",
+    srcs = ["tests/alltypes/alltypes.proto"],
+)
+
+cc_nanopb_proto_library(
+    name = "all_types_nanopb",
+    protos = [":all_types_proto"],
+    nanopb_options_file = "tests/alltypes/alltypes.options",
+    visibility = ["//visibility:private"],
+)
+
+cc_test(
+    name = "bazel_options_support",
+    srcs = ["tests/bazel_options_support/bazel_options_support.cc"],
+    deps = [":all_types_nanopb"],
+)
+
 # Run `bazel run //:requirements.update` if you want to update the requirements.
 compile_pip_requirements(
     name = "requirements",

--- a/extra/bazel/nanopb_deps.bzl
+++ b/extra/bazel/nanopb_deps.bzl
@@ -32,6 +32,7 @@ def nanopb_deps():
     if "rules_proto_grpc" not in native.existing_rules():
         http_archive(
             name = "rules_proto_grpc",
+            patches = ["//extra/bazel:rules_proto_grpc.patch"],
             sha256 = "507e38c8d95c7efa4f3b1c0595a8e8f139c885cb41a76cab7e20e4e67ae87731",
             strip_prefix = "rules_proto_grpc-4.1.1",
             urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.1.1.tar.gz"],

--- a/extra/bazel/rules_proto_grpc.patch
+++ b/extra/bazel/rules_proto_grpc.patch
@@ -1,0 +1,30 @@
+diff --git internal/compile.bzl internal/compile.bzl
+index 0f060f8..2e7f960 100644
+--- internal/compile.bzl
++++ internal/compile.bzl
+@@ -39,6 +39,11 @@ proto_compile_attrs = {
+         values = ["PREFIXED", "NO_PREFIX"],
+         doc = "The output mode for the target. PREFIXED (the default) will output to a directory named by the target within the current package root, NO_PREFIX will output directly to the current package. Using NO_PREFIX may lead to conflicting writes",
+     ),
++    "nanopb_options_file": attr.label(
++        doc = "Optional Nanopb options file for nanopb specfiically since options files couldn't be found by Bazel",
++        allow_single_file = True,
++        mandatory = False,
++    )
+ }
+
+ def proto_compile_impl(ctx):
+@@ -58,10 +63,13 @@ def proto_compile_impl(ctx):
+     # Load attrs that we pass as args
+     # This is done to allow writing rules that can call proto_compile with mutable attributes,
+     # such as in doc_template_compile
+     options = ctx.attr.options
+     extra_protoc_args = getattr(ctx.attr, "extra_protoc_args", [])
+     extra_protoc_files = ctx.files.extra_protoc_files
+
++    if ctx.file.nanopb_options_file:
++        extra_protoc_args = extra_protoc_args + ["--nanopb_plugin_opt=-f{}".format(ctx.file.nanopb_options_file.path)]
++        extra_protoc_files = ctx.files.extra_protoc_files + [ctx.file.nanopb_options_file]
+     # Execute with extracted attrs
+     return proto_compile(ctx, options, extra_protoc_args, extra_protoc_files)
+

--- a/tests/bazel_options_support/bazel_options_support.cc
+++ b/tests/bazel_options_support/bazel_options_support.cc
@@ -1,0 +1,10 @@
+#include "tests/alltypes/alltypes.pb.h"
+
+int main(int argc, char* argv[]) {
+	IntSizes intSizes;
+	if (sizeof(intSizes.req_int8) == 1) {
+		return 0;
+	} else {
+		return 1;
+	}
+}


### PR DESCRIPTION
Making a PR out of the suggestion in https://github.com/nanopb/nanopb/issues/805#issuecomment-1338272685 to support `.options` files in the provided bazel rules.

I added a bazel test to test the new support (failing on first commit, passing on second commit).