### PR TITLE
Change CMake Python package name to nanopb

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           cd examples/simple
           nanopb_generator simple.proto
-          gcc -Wall -Werror -osimple simple.pb.c simple.c -lprotobuf-nanopb
+          gcc -Wall -Werror -osimple simple.pb.c simple.c -lprotobuf-nanopb -I/usr/local/include/nanopb
           ./simple
 
   build_cmake_windows:
@@ -65,7 +65,7 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd examples/simple
-          C:\nanopb-test\bin\nanopb_generator simple.proto
-          cl /out:simple.exe simple.pb.c simple.c C:\nanopb-test\nanopb\lib\protobuf-nanopb.lib
+          call C:\nanopb-test\bin\nanopb_generator simple.proto
+          cl simple.pb.c simple.c /IC:\nanopb-test\include\nanopb C:\nanopb-test\lib\protobuf-nanopb.lib /link /out:simple.exe
           simple.exe
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,71 @@
+name: Test CMake-based installation and compilation
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - '**CMakeLists**'
+      - '**cmake**'
+  pull_request:
+    paths:
+      - '**CMakeLists**'
+      - '**cmake**'
+
+jobs:
+  build_cmake_linux:
+    name: CMake on Ubuntu 22.04
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install protobuf grpcio-tools
+
+      - name: Build with CMake
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+          sudo cmake --install .
+      
+      - name: Compile example against installed library
+        run: |
+          cd examples/simple
+          nanopb_generator simple.proto
+          gcc -Wall -Werror -osimple simple.pb.c simple.c -lprotobuf-nanopb
+          ./simple
+
+  build_cmake_windows:
+    name: CMake on Windows 2022
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install protobuf grpcio-tools
+
+      - name: Build with CMake
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --config Release
+          cmake --install . --config Release --prefix C:/nanopb-test
+      
+      - name: Compile example against installed library
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cd examples/simple
+          C:\nanopb-test\bin\nanopb_generator simple.proto
+          cl /out:simple.exe simple.pb.c simple.c C:\nanopb-test\nanopb\lib\protobuf-nanopb.lib
+          simple.exe
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,16 @@ if(nanopb_BUILD_GENERATOR)
     install( FILES generator/__init__.py
              DESTINATION ${PYTHON_INSTDIR}/nanopb/ )
 
+    # Include the full path to Python executable in Windows .bat scripts, in case it is not in PATH
+    if(WIN32)
+        file(READ generator/protoc-gen-nanopb.bat FILE_CONTENTS)
+        string(REPLACE "python" ${Python_EXECUTABLE} FILE_CONTENTS "${FILE_CONTENTS}")
+        file(WRITE ${PROJECT_BINARY_DIR}/protoc-gen-nanopb.bat "${FILE_CONTENTS}")
+
+        file(READ generator/nanopb_generator.bat FILE_CONTENTS)
+        string(REPLACE "python" ${Python_EXECUTABLE} FILE_CONTENTS "${FILE_CONTENTS}")
+        file(WRITE ${PROJECT_BINARY_DIR}/nanopb_generator.bat "${FILE_CONTENTS}")
+    endif()
 endif()
 
 # Install small script wrappers to invoke the generator from the installed module
@@ -93,8 +103,8 @@ if(WIN32)
     install(
         PROGRAMS
             extra/script_wrappers/nanopb_generator.py
-            generator/protoc-gen-nanopb.bat
-            generator/nanopb_generator.bat
+            ${PROJECT_BINARY_DIR}/protoc-gen-nanopb.bat
+            ${PROJECT_BINARY_DIR}/nanopb_generator.bat
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,17 @@ if(nanopb_BUILD_GENERATOR)
     install( FILES generator/__init__.py
              DESTINATION ${PYTHON_INSTDIR}/nanopb/ )
 
-    # Include the full path to Python executable in Windows .bat scripts, in case it is not in PATH
+    # Install a script that calls nanopb.generator Python module when invoked
+    install(
+        PROGRAMS
+            extra/script_wrappers/nanopb_generator.py
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+    # Install shell/bat script wrappers for invoking nanopb_generator.py.
+    # protoc-gen-nanopb is automatically used by protoc when --nanopb_out= option is used.
     if(WIN32)
+        # Include the full path to Python executable in Windows .bat scripts, as it is not in PATH on all systems
         file(READ generator/protoc-gen-nanopb.bat FILE_CONTENTS)
         string(REPLACE "python" ${Python_EXECUTABLE} FILE_CONTENTS "${FILE_CONTENTS}")
         file(WRITE ${PROJECT_BINARY_DIR}/protoc-gen-nanopb.bat "${FILE_CONTENTS}")
@@ -95,26 +104,22 @@ if(nanopb_BUILD_GENERATOR)
         file(READ generator/nanopb_generator.bat FILE_CONTENTS)
         string(REPLACE "python" ${Python_EXECUTABLE} FILE_CONTENTS "${FILE_CONTENTS}")
         file(WRITE ${PROJECT_BINARY_DIR}/nanopb_generator.bat "${FILE_CONTENTS}")
-    endif()
-endif()
 
-# Install small script wrappers to invoke the generator from the installed module
-if(WIN32)
-    install(
-        PROGRAMS
-            extra/script_wrappers/nanopb_generator.py
-            ${PROJECT_BINARY_DIR}/protoc-gen-nanopb.bat
-            ${PROJECT_BINARY_DIR}/nanopb_generator.bat
-        DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
-else()
-    install(
-        PROGRAMS
-            extra/script_wrappers/nanopb_generator.py
-            generator/protoc-gen-nanopb
-            generator/nanopb_generator
-        DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
+        install(
+            PROGRAMS
+                ${PROJECT_BINARY_DIR}/protoc-gen-nanopb.bat
+                ${PROJECT_BINARY_DIR}/nanopb_generator.bat
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    else()
+        # Linux/Mac scripts currently use python3 from PATH
+        install(
+            PROGRAMS
+                generator/protoc-gen-nanopb
+                generator/nanopb_generator
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif()
 endif()
 
 if(nanopb_BUILD_RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,52 +44,59 @@ endif()
 # Determine Python module installation path
 if (NOT nanopb_PYTHON_INSTDIR_OVERRIDE)
     find_package(Python REQUIRED COMPONENTS Interpreter)
-    execute_process(
-        COMMAND ${Python_EXECUTABLE} -c
-            "import os.path, sys, sysconfig; print(sysconfig.get_path('purelib'))"
-        OUTPUT_VARIABLE PYTHON_INSTDIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+    file(TO_CMAKE_PATH "${Python_SITELIB}" PYTHON_INSTDIR)
 else()
     set(PYTHON_INSTDIR ${nanopb_PYTHON_INSTDIR_OVERRIDE})
 endif()
 message(STATUS "Python install dir: ${PYTHON_INSTDIR}")
 
-# Install nanopb generator as Python module 'nanopb'
+# Package nanopb generator as Python module 'nanopb'
 if(nanopb_BUILD_GENERATOR)
-    set(generator_protos nanopb)
+    # Copy Python code files related to the generator
+    add_custom_target(nanopb_generator ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            ${PROJECT_BINARY_DIR}/nanopb/generator/proto
 
-    foreach(generator_proto IN LISTS generator_protos)
-        string(REGEX REPLACE "([^;]+)" "${PROJECT_SOURCE_DIR}/generator/proto/\\1.proto" generator_proto_file "${generator_proto}")
-        string(REGEX REPLACE "([^;]+)" "\\1_pb2.py" generator_proto_py_file "${generator_proto}")
-        add_custom_command(
-            OUTPUT ${generator_proto_py_file}
-            COMMAND ${nanopb_PROTOC_PATH} --python_out=${PROJECT_BINARY_DIR} -I${PROJECT_SOURCE_DIR}/generator/proto ${generator_proto_file}
-            DEPENDS ${generator_proto_file}
-        )
-        add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})
-        install(
-            FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
-                  ${generator_proto_file}
-            DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto/
-        )
-    endforeach()
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${PROJECT_SOURCE_DIR}/generator/proto/_utils.py
+            ${PROJECT_SOURCE_DIR}/generator/proto/__init__.py
+            ${PROJECT_SOURCE_DIR}/generator/proto/nanopb.proto
+            ${PROJECT_BINARY_DIR}/nanopb/generator/proto
 
-    install( FILES generator/proto/_utils.py
-                   generator/proto/__init__.py
-             DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto/ )
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${PROJECT_SOURCE_DIR}/generator/nanopb_generator.py
+            ${PROJECT_SOURCE_DIR}/generator/__init__.py
+            ${PROJECT_BINARY_DIR}/nanopb/generator
 
-    install( FILES generator/nanopb_generator.py
-                   generator/__init__.py
-             DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/ )
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${PROJECT_SOURCE_DIR}/generator/__init__.py
+            ${PROJECT_BINARY_DIR}/nanopb
 
-    install( FILES generator/__init__.py
-             DESTINATION ${PYTHON_INSTDIR}/nanopb/ )
+        COMMAND ${nanopb_PROTOC_PATH}
+            --python_out=${PROJECT_BINARY_DIR}/nanopb/generator/proto
+            -I${PROJECT_SOURCE_DIR}/generator/proto
+            ${PROJECT_SOURCE_DIR}/generator/proto/nanopb.proto
+    )
 
-    # Install a script that calls nanopb.generator Python module when invoked
+
+
+    # Install Python module files
     install(
-        PROGRAMS
-            extra/script_wrappers/nanopb_generator.py
+        DIRECTORY ${PROJECT_BINARY_DIR}/nanopb
+        DESTINATION ${PYTHON_INSTDIR}
+        FILES_MATCHING
+        PATTERN *.py
+        PATTERN *.proto
+        PATTERN __pycache__ EXCLUDE
+    )
+
+    # Generate a wrapper script that calls nanopb.generator Python module when invoked
+    configure_file(
+        extra/script_wrappers/nanopb_generator.py.in
+        ${PROJECT_BINARY_DIR}/nanopb_generator.py
+    )
+    install(
+        PROGRAMS ${PROJECT_BINARY_DIR}/nanopb_generator.py
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
@@ -139,7 +146,7 @@ if(nanopb_BUILD_RUNTIME)
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         target_include_directories(protobuf-nanopb INTERFACE
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nanopb>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         )
     endif()
@@ -158,7 +165,7 @@ if(nanopb_BUILD_RUNTIME)
         install(TARGETS protobuf-nanopb-static EXPORT nanopb-targets
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
         target_include_directories(protobuf-nanopb-static INTERFACE
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nanopb>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         )
     endif()
@@ -175,5 +182,5 @@ if(nanopb_BUILD_RUNTIME)
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
 
     install(FILES pb.h pb_common.h pb_encode.h pb_decode.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nanopb)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,12 @@ if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
     set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/nanopb")
 endif()
 
+# Determine Python module installation path
 if (NOT nanopb_PYTHON_INSTDIR_OVERRIDE)
     find_package(Python REQUIRED COMPONENTS Interpreter)
     execute_process(
         COMMAND ${Python_EXECUTABLE} -c
-            "import os.path, sys, sysconfig; print(os.path.relpath(sysconfig.get_path('purelib'), start=sys.prefix))"
+            "import os.path, sys, sysconfig; print(sysconfig.get_path('purelib'))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
@@ -54,6 +55,7 @@ else()
 endif()
 message(STATUS "Python install dir: ${PYTHON_INSTDIR}")
 
+# Install nanopb generator as Python module 'nanopb'
 if(nanopb_BUILD_GENERATOR)
     set(generator_protos nanopb)
 
@@ -69,27 +71,38 @@ if(nanopb_BUILD_GENERATOR)
         install(
             FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
                   ${generator_proto_file}
-            DESTINATION ${PYTHON_INSTDIR}/proto/
+            DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto/
         )
     endforeach()
 
     install( FILES generator/proto/_utils.py
                    generator/proto/__init__.py
-             DESTINATION ${PYTHON_INSTDIR}/proto/ )
+             DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto/ )
+
+    install( FILES generator/nanopb_generator.py
+                   generator/__init__.py
+             DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/ )
+
+    install( FILES generator/__init__.py
+             DESTINATION ${PYTHON_INSTDIR}/nanopb/ )
+
 endif()
 
+# Install small script wrappers to invoke the generator from the installed module
 if(WIN32)
     install(
         PROGRAMS
-            generator/nanopb_generator.py
+            extra/script_wrappers/nanopb_generator.py
             generator/protoc-gen-nanopb.bat
+            generator/nanopb_generator.bat
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 else()
     install(
         PROGRAMS
-            generator/nanopb_generator.py
+            extra/script_wrappers/nanopb_generator.py
             generator/protoc-gen-nanopb
+            generator/nanopb_generator
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,6 +6,22 @@ required modifications of user applications are explained. Also any
 error indications are included, in order to make it easier to find this
 document.
 
+Nanopb-0.4.8 (2023-xx-xx)
+-------------------------
+
+### Fix naming conflicts with CMake installation
+
+**Rationale:** Previously `CMakeLists.txt` installed nanopb Python module under name `proto` and include file directly as `/usr/include/pb.h`. These names have potential to conflict with other libraries.
+
+**Changes:** Python module is installed as `nanopb` and include files under `/usr/include/nanopb`.
+
+**Required actions:** Only affects users who install nanopb using the `cmake` build system.
+Does not affect use of `FindNanopb.cmake`.
+Calling nanopb generator should work as before.
+Include path may need adjustment if not using `nanopb-targets.cmake` to determine it.
+
+**Error indications:** Include file `pb.h` not found when compiling against a system-wide installation done with CMake.
+
 Nanopb-0.4.7 (2022-xx-xx)
 -------------------------
 

--- a/extra/script_wrappers/nanopb_generator.py
+++ b/extra/script_wrappers/nanopb_generator.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# This script is a wrapper to invoke nanopb_generator from an installed Python module.
+import sys
+from nanopb.generator.nanopb_generator import main_cli, main_plugin
+if __name__ == '__main__':
+    sys.exit(main_cli())

--- a/extra/script_wrappers/nanopb_generator.py
+++ b/extra/script_wrappers/nanopb_generator.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-# This script is a wrapper to invoke nanopb_generator from an installed Python module.
-import sys
-from nanopb.generator.nanopb_generator import main_cli, main_plugin
-if __name__ == '__main__':
-    sys.exit(main_cli())

--- a/extra/script_wrappers/nanopb_generator.py.in
+++ b/extra/script_wrappers/nanopb_generator.py.in
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# This script is a wrapper to invoke nanopb_generator from an installed Python module.
+import sys
+import os.path
+
+# CMakeLists.txt can provide this file the path to Python module installation
+# location. It is used as a relative path. By default only system path is used.
+python_instdir = r"@PYTHON_INSTDIR@"
+cmake_bindir = r"@CMAKE_INSTALL_BINDIR@"
+cmake_install_prefix = r"@CMAKE_INSTALL_PREFIX@"
+if python_instdir[0] != '@':
+    python_instdir = os.path.join(cmake_install_prefix, python_instdir)
+    cmake_bindir = os.path.join(cmake_install_prefix, cmake_bindir)
+    relpath = os.path.relpath(python_instdir, cmake_bindir)
+    bindir = os.path.dirname(os.path.realpath(__file__))
+    libdir = os.path.abspath(os.path.join(bindir, relpath))
+    if os.path.isdir(libdir):
+        sys.path.insert(0, libdir) # Path after make install
+    else:
+        sys.path.insert(0, bindir) # Path before make install
+
+from nanopb.generator.nanopb_generator import main_cli, main_plugin
+if __name__ == '__main__':
+    sys.exit(main_cli())

--- a/generator/nanopb_generator
+++ b/generator/nanopb_generator
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# Allow calling nanopb_generator.py as simply nanopb_generator.
+# This provides consistency with packages installed through CMake or pip.
+
+from nanopb_generator import *
+if __name__ == '__main__':
+    main_cli()

--- a/generator/nanopb_generator.bat
+++ b/generator/nanopb_generator.bat
@@ -1,0 +1,5 @@
+@echo off
+:: Allow calling nanopb_generator.py as simply nanopb_generator.
+:: This provides consistency with packages installed through CMake or pip.
+set mydir=%~dp0
+python "%mydir%\nanopb_generator.py" %*


### PR DESCRIPTION
Previously CMakeLists.txt would install the nanopb components as a Python package called `proto`.
This would conflict with other packages (such as `python3-proto-plus`) (#845).

This pull request changes the directory structure to match what `pip install nanopb` produces.
The Python package is now called `nanopb`, and there are small wrapper scripts installed under `bin` to import the module.

Also added a GitHub workflow to test CMake installation.

@nicholas-stpierre-simplisafe @avikde @ianjfrosst @shahsahi If any of you has time to try out CMake installation from the branch dev_cmake_python_install that would be great. Just in case there is some regression for existing users.