### PR TITLE
Fix python install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,19 @@ if(nanopb_BUILD_GENERATOR)
         )
         add_custom_target("generate_${generator_proto_py_file}" ALL DEPENDS ${generator_proto_py_file})
         install(
-            FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
-                  ${generator_proto_file}
-            DESTINATION ${PYTHON_INSTDIR}/proto/
+            FILES
+                ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
+                ${generator_proto_file}
+            DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto
         )
     endforeach()
 
-    install( FILES generator/proto/_utils.py
-                   generator/proto/__init__.py
-             DESTINATION ${PYTHON_INSTDIR}/proto/ )
+    install(
+        FILES
+            generator/proto/_utils.py
+            generator/proto/__init__.py
+        DESTINATION ${PYTHON_INSTDIR}/nanopb/generator/proto
+    )
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,12 +43,7 @@ endif()
 
 if (NOT nanopb_PYTHON_INSTDIR_OVERRIDE)
     find_package(Python REQUIRED COMPONENTS Interpreter)
-    execute_process(
-        COMMAND ${Python_EXECUTABLE} -c
-            "import os.path, sys, sysconfig; print(os.path.relpath(sysconfig.get_path('purelib'), start=sys.prefix))"
-        OUTPUT_VARIABLE PYTHON_INSTDIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+    set(PYTHON_INSTDIR ${Python_SITELIB})
 else()
     set(PYTHON_INSTDIR ${nanopb_PYTHON_INSTDIR_OVERRIDE})
 endif()

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -50,9 +50,9 @@ except:
 # Depending on how this script is run, we may or may not have PEP366 package name
 # available for relative imports.
 if not __package__:
-    import proto
-    from proto._utils import invoke_protoc
-    from proto import TemporaryDirectory
+    from nanopb.generator import proto
+    from nanopb.generator.proto._utils import invoke_protoc
+    from nanopb.generator.proto import TemporaryDirectory
 else:
     from . import proto
     from .proto._utils import invoke_protoc


### PR DESCRIPTION
The PYTHON_INSTDIR must be absolute because it is independent from the project and CMAKE_INSTALL_PREFIX. It could be overridden by the nanopb_PYTHON_INSTDIR_OVERRIDE. Furthermore use the python install directory from the nanopb python package to resolve #845.