### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+protobuf
+grpcio-tools


### PR DESCRIPTION
This pull requests proposes python `requirements.txt` file with listed module dependencies.

A simple run of `pip install -r requirements.txt` will automatically load required libs.
It can be future updated with new libs.