### PR TITLE
library proporties proposal for Arduino Library registry

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Nanopb
+version=0.4.8
+author=Petteri Aimonen <jpa@npb.mail.kapsi.fi>
+maintainer=Antonio Vanegas <hpsaturn@gmail.com>
+sentence=protocol buffers, protobuf, google
+paragraph=Nanopb is a plain-C implementation of Google's Protocol Buffers data format. It is targeted at 32 bit microcontrollers, but is also fit for other embedded systems with tight (<10 kB ROM, <1 kB RAM) memory constraints.
+category=Communication
+url=https://github.com/nanopb/nanopb.git
+architectures=*


### PR DESCRIPTION
## Overview

The idea with this PR is try to have a better experience for Arduino users, trying to have the library in the Library Manager of Arduino IDE. Also to resolve some issues with other libraries that using Nanopb like a dependency in this ecosystem.

## Tasks

- [x] library.properties proposal (extracted from the PlatformIO manifest, library.json)
- [ ] fix link symbolic issue with `arduino-lint` tool (lookup for a solution)

## Issues

The implementation of Arduino IDE registry is very bad in comparation with PlatformIO registry, for instance Arduino Library Registry doesn't have support for link symbolic. If you pass the `arduino-lint` we have:

```bash
Linting library in /home/avp/pio/nanopb
ERROR: Symlink(s) found. Symlinks cause difficulties for Windows users. These block addition to the Arduino Library
```