### PR TITLE
Change check_ccflags to TryLink

### DIFF
--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -81,7 +81,7 @@ if not env.GetOption('clean'):
         oldlinkflags = context.env['LINKFLAGS']
         context.env.Append(CCFLAGS = flags)
         context.env.Append(LINKFLAGS = linkflags)
-        result = context.TryCompile("int main() {return 0;}", '.c')
+        result = context.TryLink("int main() {return 0;}", '.c')
         context.env.Replace(CCFLAGS = oldflags)
         context.env.Replace(LINKFLAGS = oldlinkflags)
         context.Result(result)


### PR DESCRIPTION
Trying to compile and run tests using IAR compiler i came across the following issue:

`CheckCCFlags('','-lm') ` always succeeeds even when libm doesn't exist since it doesn't actually try to link.
The Code in question:
https://github.com/nanopb/nanopb/blob/5fd8f04a48be1a250c3bbdc9f7c782ef2c372e74/tests/SConstruct#L84
Excerpt from config.log

```
scons: Configure: Checking support for CCFLAGS="" LINKFLAGS="-lm"...
scons: Configure: "build/config/conftest_cf2934b4600b480723adfae3b58d5f1b_0.c" is up to date.
scons: Configure: The original builder output was:
  |build/config/conftest_cf2934b4600b480723adfae3b58d5f1b_0.c <-
  |  |int main() {return 0;}
  |
scons: Configure: "build/config/conftest_cf2934b4600b480723adfae3b58d5f1b_0_f31a9d447b06d437e00c7f1832a0495d.o" is up to date.
scons: Configure: The original builder output was:
  |iccarm -o build/config/conftest_cf2934b4600b480723adfae3b58d5f1b_0_f31a9d447b06d437e00c7f1832a0495d.o -c -e --dlib_config DLib_Config_Full.h -I/mnt/d/nanopb build/config/conftest_cf2934b4600b480723adfae3b58d5f1b_0.c
```

But later...

```
scons: Building targets ...
ilinkarm -o build/alltypes/decode_alltypes --no_out_extension --semihosting -lm build/alltypes/decode_alltypes.o build/alltypes/alltypes.pb.o build/common/pb_decode.o build/common/pb_common.o

   IAR ELF Linker V9.50.1.380/LNX for ARM BX
   Copyright 2007-2023 IAR Systems AB.
Fatal error[Ms007]: could not open file "libm.a"
            Directories searched:
              /mnt/d/nanopb/tests
Fatal error detected, aborting.
scons: *** [build/alltypes/decode_alltypes] Error 3
```

Is changing to TryLink enough? I am not really familiar with scons but this seems to be the intention of the code.
