### PR TITLE
Add has_msgid() and msgid() methods to C++ message descriptors

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1525,6 +1525,12 @@ class Message(ProtoElement):
         result += '    static inline const pb_msgdesc_t* fields() {\n'
         result += '        return &%s_msg;\n' % (self.name)
         result += '    }\n'
+        result += '    static inline bool has_msgid() {\n'
+        result += '        return %s;\n' % ("true" if hasattr(self, "msgid") else "false", )
+        result += '    }\n'
+        result += '    static inline int32_t msgid() {\n'
+        result += '        return %d;\n' % (getattr(self, "msgid", 0), )
+        result += '    }\n'
         result += '};'
         return result
 

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1528,7 +1528,7 @@ class Message(ProtoElement):
         result += '    static inline bool has_msgid() {\n'
         result += '        return %s;\n' % ("true" if hasattr(self, "msgid") else "false", )
         result += '    }\n'
-        result += '    static inline int32_t msgid() {\n'
+        result += '    static inline uint32_t msgid() {\n'
         result += '        return %d;\n' % (getattr(self, "msgid", 0), )
         result += '    }\n'
         result += '};'

--- a/tests/cxx_descriptor/message.proto
+++ b/tests/cxx_descriptor/message.proto
@@ -10,3 +10,13 @@ message MyEmptyMessage {
 message MyNonEmptyMessage {
     optional uint32 field = 1;
 }
+
+message MyMessageWithMsgid {
+    option (nanopb_msgopt).msgid = 42;
+    optional uint32 field = 1;
+}
+
+message MyMessageWithoutMsgid {
+    optional uint32 field = 1;
+}
+

--- a/tests/cxx_descriptor/message_descriptor.cc
+++ b/tests/cxx_descriptor/message_descriptor.cc
@@ -23,6 +23,12 @@ extern "C" int main() {
   TEST(MessageDescriptor<MyNonEmptyMessage>::fields() ==
        MyNonEmptyMessage_fields);
 
+  TEST(MessageDescriptor<MyMessageWithMsgid>::has_msgid() == true);
+  TEST(MessageDescriptor<MyMessageWithMsgid>::msgid() == 42);
+
+  TEST(MessageDescriptor<MyMessageWithoutMsgid>::has_msgid() == false);
+
+
   if (status != 0) fprintf(stdout, "\n\nSome tests FAILED!\n");
 
   return status;


### PR DESCRIPTION
The existing C++ message descriptors are useful for use in templated message packing/unpacking code.
This PR adds has_msgid() and msgid() methods for the MessageDescriptor<> class.