### PR TITLE
Add message sizes to C++ wrappers.

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1525,7 +1525,7 @@ class Message(ProtoElement):
 
         size_define = "%s_size" % (self.name)
         if size_define in local_defines:
-            result += '    static PB_INLINE_CONSTEXPR const pb_size_t max_size = %s;\n' % (size_define)
+            result += '    static PB_INLINE_CONSTEXPR const pb_size_t size = %s;\n' % (size_define)
 
         result += '    static inline const pb_msgdesc_t* fields() {\n'
         result += '        return &%s_msg;\n' % (self.name)

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1518,10 +1518,14 @@ class Message(ProtoElement):
 
         return result
 
-    def fields_declaration_cpp_lookup(self):
+    def fields_declaration_cpp_lookup(self, local_defines):
         result = 'template <>\n'
         result += 'struct MessageDescriptor<%s> {\n' % (self.name)
         result += '    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = %d;\n' % (self.count_all_fields())
+
+        if f"{self.name}_size" in local_defines:
+            result += '    static PB_INLINE_CONSTEXPR const pb_size_t max_size = %s_size;\n' % (self.name)
+
         result += '    static inline const pb_msgdesc_t* fields() {\n'
         result += '        return &%s_msg;\n' % (self.name)
         result += '    }\n'
@@ -2167,7 +2171,7 @@ class ProtoFile:
             yield '/* Message descriptors for nanopb */\n'
             yield 'namespace nanopb {\n'
             for msg in self.messages:
-                yield msg.fields_declaration_cpp_lookup() + '\n'
+                yield msg.fields_declaration_cpp_lookup(local_defines) + '\n'
             yield '}  // namespace nanopb\n'
             yield '\n'
             yield '#endif  /* __cplusplus */\n'

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1523,8 +1523,9 @@ class Message(ProtoElement):
         result += 'struct MessageDescriptor<%s> {\n' % (self.name)
         result += '    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = %d;\n' % (self.count_all_fields())
 
-        if f"{self.name}_size" in local_defines:
-            result += '    static PB_INLINE_CONSTEXPR const pb_size_t max_size = %s_size;\n' % (self.name)
+        size_define = "%s_size" % (self.name)
+        if size_define in local_defines:
+            result += '    static PB_INLINE_CONSTEXPR const pb_size_t max_size = %s;\n' % (size_define)
 
         result += '    static inline const pb_msgdesc_t* fields() {\n'
         result += '        return &%s_msg;\n' % (self.name)

--- a/tests/cxx_descriptor/SConscript
+++ b/tests/cxx_descriptor/SConscript
@@ -24,5 +24,5 @@ for std in ["c++03", "c++11", "c++14", "c++17", "c++20"]:
 
     o1 = e.Object('message_descriptor_{}'.format(std), 'message_descriptor.cc')
     o2 = e.Object('message.pb_{}'.format(std), 'message.pb.c')
-    p = e.Program([o1, o2])
+    p = e.Program([o1, o2, "$COMMON/pb_common.o"])
     e.RunTest(p)

--- a/tests/cxx_descriptor/message.proto
+++ b/tests/cxx_descriptor/message.proto
@@ -20,3 +20,15 @@ message MyMessageWithoutMsgid {
     optional uint32 field = 1;
 }
 
+// This message is not used in the tests but is rather a sentry message that
+// will trigger a build failure if the generator decides to create a size
+// variable for fields which are not size bound. Note that this only works as
+// long as the C++ interface for sizing wraps the C interface.
+message MyMessageWithoutSize {
+    repeated uint32 field = 1;
+}
+
+message MyMessageWithSizeBoundRepeatedFields {
+    option (nanopb_msgopt).max_count = 100;
+    repeated uint32 field = 1;
+}

--- a/tests/cxx_descriptor/message_descriptor.cc
+++ b/tests/cxx_descriptor/message_descriptor.cc
@@ -19,7 +19,7 @@ extern "C" int main() {
   TEST(MessageDescriptor<MyNonEmptyMessage>::fields_array_length ==
        MyNonEmptyMessage_msg.field_count);
 
-  TEST(MessageDescriptor<MyNonEmptyMessage>::max_size ==
+  TEST(MessageDescriptor<MyNonEmptyMessage>::size ==
        MyNonEmptyMessage_size);
 
   TEST(MessageDescriptor<MyEmptyMessage>::fields() == MyEmptyMessage_fields);

--- a/tests/cxx_descriptor/message_descriptor.cc
+++ b/tests/cxx_descriptor/message_descriptor.cc
@@ -19,6 +19,9 @@ extern "C" int main() {
   TEST(MessageDescriptor<MyNonEmptyMessage>::fields_array_length ==
        MyNonEmptyMessage_msg.field_count);
 
+  TEST(MessageDescriptor<MyNonEmptyMessage>::max_size ==
+       MyNonEmptyMessage_size);
+
   TEST(MessageDescriptor<MyEmptyMessage>::fields() == MyEmptyMessage_fields);
   TEST(MessageDescriptor<MyNonEmptyMessage>::fields() ==
        MyNonEmptyMessage_fields);

--- a/tests/cxx_descriptor/message_descriptor.cc
+++ b/tests/cxx_descriptor/message_descriptor.cc
@@ -21,6 +21,8 @@ extern "C" int main() {
 
   TEST(MessageDescriptor<MyNonEmptyMessage>::size ==
        MyNonEmptyMessage_size);
+  TEST(MessageDescriptor<MyMessageWithSizeBoundRepeatedFields>::size ==
+       MyMessageWithSizeBoundRepeatedFields_size);
 
   TEST(MessageDescriptor<MyEmptyMessage>::fields() == MyEmptyMessage_fields);
   TEST(MessageDescriptor<MyNonEmptyMessage>::fields() ==


### PR DESCRIPTION
This adds a max_size field referring to the C #define, indicating the maximum encoded size of that message type. If the size cannot be determined, for example due to non-bounded repeated fields, the constant is omitted.

If anyone knows how to test for absence of types in C++ I'm all ears :)

This closes #932