### PR TITLE
[nanopb] Add Apple privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -25,6 +25,7 @@ let package = Package(
         "pb_encode.h",
         "pb_encode.c"
       ],
+      resources: [.process("spm_resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "spm_headers",
       cSettings: [
         .define("PB_FIELD_32BIT", to: "1"),

--- a/spm_resources/PrivacyInfo.xcprivacy
+++ b/spm_resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>
+


### PR DESCRIPTION
Add a privacy manifest for nanopb. The library does not use any ["required reason API"](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).

Proposing to:
- merge this in the `maintenance_0.3` branch
- publish a `0.3.9.10`  tag after merging

Fixes #910

cc: @paulb777 