### PR TITLE
Support zephyr module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ There exist build rules for several systems:
 And also integration to platform interfaces:
 
 * **Arduino**: http://platformio.org/lib/show/1385/nanopb-arduino
+* **Zephyr**: https://docs.zephyrproject.org/latest/services/serialization/nanopb.html
 

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: nanopb
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
This PR allows using `nanopb` as a [zephyr](https://docs.zephyrproject.org/latest/services/serialization/nanopb.html) module directly, instead of maintaining/merging a specific downstream copy.