### PR TITLE
Store all field descriptor parts in program memory on AVR to save SRAM

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -150,9 +150,20 @@ extern "C" {
 #include <avr/pgmspace.h>
 #define PB_PROGMEM             PROGMEM
 #define PB_PROGMEM_READU32(x)  pgm_read_dword(&x)
+#if defined(PB_FIELD_32BIT)
+#define PB_PROGMEM_READSIZE(x) PB_PROGMEM_READU32(x)
+#else
+#define PB_PROGMEM_READSIZE(x) pgm_read_word(&x)
+#endif
+#define PB_PROGMEM_READPTR(x) pgm_read_ptr(&x)
+#define PB_PROGMEM_READBYTE(x) pgm_read_byte(&x)
 #else
 #define PB_PROGMEM
 #define PB_PROGMEM_READU32(x)  (x)
+#define PB_PROGMEM_READSIZE(x) (x)
+#define PB_PROGMEM_READPTR(x) (x)
+#define PB_PROGMEM_READBYTE(x) (x)
+
 #endif
 #endif
 
@@ -502,18 +513,19 @@ struct pb_extension_s {
 #define PB_EXPAND(x) x
 
 /* Binding of a message field set into a specific structure */
+// const pb_byte_t structname ## _defaults[] PB_PROGMEM = msgname ## _DEFAULT;`
 #define PB_BIND(msgname, structname, width) \
     const uint32_t structname ## _field_info[] PB_PROGMEM = \
     { \
         msgname ## _FIELDLIST(PB_GEN_FIELD_INFO_ ## width, structname) \
         0 \
     }; \
-    const pb_msgdesc_t* const structname ## _submsg_info[] = \
+    const pb_msgdesc_t* const structname ## _submsg_info[] PB_PROGMEM = \
     { \
         msgname ## _FIELDLIST(PB_GEN_SUBMSG_INFO, structname) \
         NULL \
     }; \
-    const pb_msgdesc_t structname ## _msg = \
+    const pb_msgdesc_t structname ## _msg PB_PROGMEM = \
     { \
        structname ## _field_info, \
        structname ## _submsg_info, \

--- a/pb.h
+++ b/pb.h
@@ -146,26 +146,25 @@ extern "C" {
 /* Harvard-architecture processors may need special attributes for storing
  * field information in program memory. */
 #ifndef PB_PROGMEM
-#ifdef __AVR__
-#include <avr/pgmspace.h>
-#define PB_PROGMEM             PROGMEM
-#define PB_PROGMEM_READU32(x)  pgm_read_dword(&x)
-#if defined(PB_FIELD_32BIT)
-#define PB_PROGMEM_READSIZE(x) PB_PROGMEM_READU32(x)
-#else
-#define PB_PROGMEM_READSIZE(x) pgm_read_word(&x)
-#endif
-#define PB_PROGMEM_READPTR(x) pgm_read_ptr(&x)
-#define PB_PROGMEM_READBYTE(x) pgm_read_byte(&x)
-#else
-#define PB_PROGMEM
-#define PB_PROGMEM_READU32(x)  (x)
-#define PB_PROGMEM_READSIZE(x) (x)
-#define PB_PROGMEM_READPTR(x) (x)
-#define PB_PROGMEM_READBYTE(x) (x)
-
-#endif
-#endif
+#   ifdef __AVR__
+#       include <avr/pgmspace.h>
+#       define PB_PROGMEM                 PROGMEM
+#       define PB_PROGMEM_READU32(x)      pgm_read_dword(&x)
+#       if defined(PB_FIELD_32BIT)
+#           define PB_PROGMEM_READSIZE(x) PB_PROGMEM_READU32(x)
+#       else /* !PB_FIELD_32BIT */
+#           define PB_PROGMEM_READSIZE(x) pgm_read_word(&x)
+#       endif /* !PB_FIELD_32BIT */
+#       define PB_PROGMEM_READPTR(x)      pgm_read_ptr(&x)
+#       define PB_PROGMEM_READBYTE(x)     pgm_read_byte(&x)
+#   else /* !__AVR__ */
+#       define PB_PROGMEM
+#       define PB_PROGMEM_READU32(x)      (x)
+#       define PB_PROGMEM_READSIZE(x)     (x)
+#       define PB_PROGMEM_READPTR(x)      (x)
+#       define PB_PROGMEM_READBYTE(x)     (x)
+#   endif /* !__AVR__ */
+#endif /* !PB_PROGMEM */
 
 /* Compile-time assertion, used for checking compatible compilation options.
  * If this does not work properly on your compiler, use

--- a/pb.h
+++ b/pb.h
@@ -513,7 +513,6 @@ struct pb_extension_s {
 #define PB_EXPAND(x) x
 
 /* Binding of a message field set into a specific structure */
-// const pb_byte_t structname ## _defaults[] PB_PROGMEM = msgname ## _DEFAULT;`
 #define PB_BIND(msgname, structname, width) \
     const uint32_t structname ## _field_info[] PB_PROGMEM = \
     { \

--- a/pb_common.c
+++ b/pb_common.c
@@ -167,12 +167,10 @@ bool pb_field_iter_begin(pb_field_iter_t *iter, const pb_msgdesc_t *desc, void *
 
 bool pb_field_iter_begin_extension(pb_field_iter_t *iter, pb_extension_t *extension)
 {
-    return false;
-    // TODO: hjelp
     const pb_msgdesc_t *msg = (const pb_msgdesc_t*)extension->type->arg;
     bool status;
 
-    uint32_t word0 = PB_PROGMEM_READU32(msg->field_info[0]);
+    uint32_t word0 = PB_PROGMEM_READU32(((const uint32_t*)PB_PROGMEM_READPTR(msg->field_info))[0]);
     if (PB_ATYPE(word0 >> 8) == PB_ATYPE_POINTER)
     {
         /* For pointer extensions, the pointer is stored directly
@@ -264,7 +262,7 @@ bool pb_field_iter_find_extension(pb_field_iter_t *iter)
             advance_iterator(iter);
 
             /* Do fast check for field type */
-            fieldinfo = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index]);
+            fieldinfo = PB_PROGMEM_READU32(((const uint32_t*)PB_PROGMEM_READPTR(iter->descriptor->field_info))[iter->field_info_index]);
 
             if (PB_LTYPE((fieldinfo >> 8) & 0xFF) == PB_LTYPE_EXTENSION)
             {

--- a/pb_common.c
+++ b/pb_common.c
@@ -11,10 +11,11 @@ static bool load_descriptor_values(pb_field_iter_t *iter)
     uint32_t data_offset;
     int_least8_t size_offset;
 
-    if (iter->index >= iter->descriptor->field_count)
+    if (iter->index >= PB_PROGMEM_READSIZE(iter->descriptor->field_count))
         return false;
 
-    word0 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index]);
+    const uint32_t* field_info = ((const uint32_t*)PB_PROGMEM_READPTR(iter->descriptor->field_info));
+    word0 = PB_PROGMEM_READU32(field_info[iter->field_info_index]);
     iter->type = (pb_type_t)((word0 >> 8) & 0xFF);
 
     switch(word0 & 3)
@@ -31,7 +32,7 @@ static bool load_descriptor_values(pb_field_iter_t *iter)
 
         case 1: {
             /* 2-word format */
-            uint32_t word1 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 1]);
+            uint32_t word1 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 1]);
 
             iter->array_size = (pb_size_t)((word0 >> 16) & 0x0FFF);
             iter->tag = (pb_size_t)(((word0 >> 2) & 0x3F) | ((word1 >> 28) << 6));
@@ -43,9 +44,9 @@ static bool load_descriptor_values(pb_field_iter_t *iter)
 
         case 2: {
             /* 4-word format */
-            uint32_t word1 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 1]);
-            uint32_t word2 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 2]);
-            uint32_t word3 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 3]);
+            uint32_t word1 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 1]);
+            uint32_t word2 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 2]);
+            uint32_t word3 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 3]);
 
             iter->array_size = (pb_size_t)(word0 >> 16);
             iter->tag = (pb_size_t)(((word0 >> 2) & 0x3F) | ((word1 >> 8) << 6));
@@ -57,10 +58,10 @@ static bool load_descriptor_values(pb_field_iter_t *iter)
 
         default: {
             /* 8-word format */
-            uint32_t word1 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 1]);
-            uint32_t word2 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 2]);
-            uint32_t word3 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 3]);
-            uint32_t word4 = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index + 4]);
+            uint32_t word1 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 1]);
+            uint32_t word2 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 2]);
+            uint32_t word3 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 3]);
+            uint32_t word4 = PB_PROGMEM_READU32(field_info[iter->field_info_index + 4]);
 
             iter->array_size = (pb_size_t)word4;
             iter->tag = (pb_size_t)(((word0 >> 2) & 0x3F) | ((word1 >> 8) << 6));
@@ -109,7 +110,8 @@ static bool load_descriptor_values(pb_field_iter_t *iter)
 
     if (PB_LTYPE_IS_SUBMSG(iter->type))
     {
-        iter->submsg_desc = iter->descriptor->submsg_info[iter->submessage_index];
+        const pb_msgdesc_t * const * submsg_info = (const pb_msgdesc_t * const *)PB_PROGMEM_READPTR(iter->descriptor->submsg_info);
+        iter->submsg_desc = PB_PROGMEM_READPTR(submsg_info[iter->submessage_index]);
     }
     else
     {
@@ -123,7 +125,7 @@ static void advance_iterator(pb_field_iter_t *iter)
 {
     iter->index++;
 
-    if (iter->index >= iter->descriptor->field_count)
+    if (iter->index >= PB_PROGMEM_READSIZE(iter->descriptor->field_count))
     {
         /* Restart */
         iter->index = 0;
@@ -139,7 +141,7 @@ static void advance_iterator(pb_field_iter_t *iter)
          * - bits 2..7 give the lowest bits of tag number.
          * - bits 8..15 give the field type.
          */
-        uint32_t prev_descriptor = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index]);
+        uint32_t prev_descriptor = PB_PROGMEM_READU32(((const uint32_t*)PB_PROGMEM_READPTR(iter->descriptor->field_info))[iter->field_info_index]);
         pb_type_t prev_type = (prev_descriptor >> 8) & 0xFF;
         pb_size_t descriptor_len = (pb_size_t)(1 << (prev_descriptor & 3));
 
@@ -165,6 +167,8 @@ bool pb_field_iter_begin(pb_field_iter_t *iter, const pb_msgdesc_t *desc, void *
 
 bool pb_field_iter_begin_extension(pb_field_iter_t *iter, pb_extension_t *extension)
 {
+    return false;
+    // TODO: hjelp
     const pb_msgdesc_t *msg = (const pb_msgdesc_t*)extension->type->arg;
     bool status;
 
@@ -198,7 +202,7 @@ bool pb_field_iter_find(pb_field_iter_t *iter, uint32_t tag)
     {
         return true; /* Nothing to do, correct field already. */
     }
-    else if (tag > iter->descriptor->largest_tag)
+    else if (tag > PB_PROGMEM_READSIZE(iter->descriptor->largest_tag))
     {
         return false;
     }
@@ -212,7 +216,7 @@ bool pb_field_iter_find(pb_field_iter_t *iter, uint32_t tag)
             /* Fields are in tag number order, so we know that tag is between
              * 0 and our start position. Setting index to end forces
              * advance_iterator() call below to restart from beginning. */
-            iter->index = iter->descriptor->field_count;
+            iter->index = PB_PROGMEM_READSIZE(iter->descriptor->field_count);
         }
 
         do
@@ -221,7 +225,7 @@ bool pb_field_iter_find(pb_field_iter_t *iter, uint32_t tag)
             advance_iterator(iter);
 
             /* Do fast check for tag number match */
-            fieldinfo = PB_PROGMEM_READU32(iter->descriptor->field_info[iter->field_info_index]);
+            fieldinfo = PB_PROGMEM_READU32(((const uint32_t*)PB_PROGMEM_READPTR(iter->descriptor->field_info))[iter->field_info_index]);
 
             if (((fieldinfo >> 2) & 0x3F) == (tag & 0x3F))
             {

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -966,12 +966,6 @@ static bool pb_message_set_to_defaults(pb_field_iter_t *iter)
         // size_t default_len = strlen_P(default_values);
         // const pb_byte_t defaults[50]={0};
         // strcpy_P((char*)defaults, default_values);
-        // // for (uint8_t i = 0; i< 250; i++) {
-        // //     pb_byte_t byte = PB_PROGMEM_READBYTE(default_values[i]);
-        // //     if (byte == 0) {
-        // //         break;
-        // //     }
-        // // }
 
         defstream = pb_istream_from_buffer(default_values, (size_t)-1);
         if (!pb_decode_tag(&defstream, &wire_type, &tag, &eof))

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -847,7 +847,6 @@ static bool checkreturn default_extension_decoder(pb_istream_t *stream,
 static bool checkreturn decode_extension(pb_istream_t *stream,
     uint32_t tag, pb_wire_type_t wire_type, pb_extension_t *extension)
 {
-    // TODO: Check this for progmem
     size_t pos = stream->bytes_left;
     
     while (extension != NULL && pos == stream->bytes_left)
@@ -960,12 +959,6 @@ static bool pb_message_set_to_defaults(pb_field_iter_t *iter)
 
     if (default_values)
     {
-        // TODO: This kinda logic will be needed if we get these defaults into PROGMEM
-
-        // size_t default_len = strlen_P(default_values);
-        // const pb_byte_t defaults[50]={0};
-        // strcpy_P((char*)defaults, default_values);
-
         defstream = pb_istream_from_buffer(default_values, (size_t)-1);
         if (!pb_decode_tag(&defstream, &wire_type, &tag, &eof))
             return false;

--- a/pb_decode.c
+++ b/pb_decode.c
@@ -960,8 +960,7 @@ static bool pb_message_set_to_defaults(pb_field_iter_t *iter)
 
     if (default_values)
     {
-        // return false;
-        // // TODO: This kinda logic will be needed if we get these defaults into PROGMEM
+        // TODO: This kinda logic will be needed if we get these defaults into PROGMEM
 
         // size_t default_len = strlen_P(default_values);
         // const pb_byte_t defaults[50]={0};

--- a/pb_encode.c
+++ b/pb_encode.c
@@ -487,7 +487,6 @@ static bool checkreturn default_extension_encoder(pb_ostream_t *stream, const pb
  * to encode themselves. */
 static bool checkreturn encode_extension_field(pb_ostream_t *stream, const pb_field_iter_t *field)
 {
-    // TODO: Check this
     const pb_extension_t *extension = *(const pb_extension_t* const *)field->pData;
 
     while (extension)


### PR DESCRIPTION
We were having some issues with our builds targeting AVR based MCUs as we only have 8KB SRAM available and the `*_msg` and `*_submsg_info` constants were filling up our SRAM a decent amount. So I did some digging and expanded the PROGMEM support in nanopb to extend to the `*_msg` and `*_submsg_info` parts instead of just `_field_info`.

This has resulted in very significant savings to our builds. Averaging a 11% reduction in static SRAM allocations.

In my testing, this appears to work correctly in our usage of nanopb. However, we do not make any use of extension fields and the code for that is a bit trickier. I did some digging and I hope that it should also be working normally as well.