### PR TITLE
Include C source files in pip package

### DIFF
--- a/extra/poetry/poetry_build.sh
+++ b/extra/poetry/poetry_build.sh
@@ -11,7 +11,7 @@ cd build
 ln -s ../dist .
 
 mkdir nanopb
-tar xf tmp.tar README.md generator
+tar xf tmp.tar README.md generator *.c *.h
 mv generator nanopb/
 touch nanopb/__init__.py nanopb/generator/__init__.py
 make -C nanopb/generator/proto

--- a/extra/poetry/pyproject.toml
+++ b/extra/poetry/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://jpa.kapsi.fi/nanopb/"
 documentation = "https://jpa.kapsi.fi/nanopb/docs/index.html"
 keywords = ["protobuf", "protoc"]
 classifiers = ["Topic :: Software Development :: Build Tools"]
-include = ["nanopb/**/*", "nanopb/__init__.py"]
+include = ["nanopb/**/*", "nanopb/__init__.py", "*.c", "*.h"]
 
 [tool.poetry.scripts]
 nanopb_generator = "nanopb.generator.nanopb_generator:main_cli"


### PR DESCRIPTION
## Commit message

Include all nanopb C source files as part of the Pip package to make updating nanopb more convenient for pip users.

Before this commit, updating nanopb took two steps: update the nanopb pip package, then update the nanopb C source files. Now updating nanopb takes only one step (i.e., update the pip package), which avoids the possibility of users updating the generator and forgetting to update the source files.

The source files show up in the root of the package:

    (.venv) ~/.../extra/poetry$ python -m zipfile --list dist/nanopb-0.4.9.dev1465-py2.py3-none-any.whl
    File Name                                             Modified             Size
    nanopb/__init__.py                             1980-01-01 00:00:00            0
    nanopb/generator/__init__.py                   1980-01-01 00:00:00            0
    nanopb/generator/nanopb_generator              1980-01-01 00:00:00          235
    nanopb/generator/nanopb_generator.bat          1980-01-01 00:00:00          206
    nanopb/generator/nanopb_generator.py           1980-01-01 00:00:00       112055
    nanopb/generator/nanopb_generator.py2          1980-01-01 00:00:00          460
    nanopb/generator/platformio_generator.py       1980-01-01 00:00:00         5839
    nanopb/generator/proto/Makefile                1980-01-01 00:00:00          126
    nanopb/generator/proto/__init__.py             1980-01-01 00:00:00         4851
    nanopb/generator/proto/_utils.py               1980-01-01 00:00:00         2790
    nanopb/generator/proto/google/protobuf/descriptor.proto 1980-01-01 00:00:00        36277
    nanopb/generator/proto/nanopb.proto            1980-01-01 00:00:00         7139
    nanopb/generator/proto/nanopb_pb2.py           1980-01-01 00:00:00         4443
    nanopb/generator/protoc                        1980-01-01 00:00:00         1577
    nanopb/generator/protoc-gen-nanopb             1980-01-01 00:00:00          374
    nanopb/generator/protoc-gen-nanopb-py2         1980-01-01 00:00:00          554
    nanopb/generator/protoc-gen-nanopb.bat         1980-01-01 00:00:00          449
    nanopb/generator/protoc.bat                    1980-01-01 00:00:00          302
    pb.h                                           1980-01-01 00:00:00        44076
    pb_common.c                                    1980-01-01 00:00:00        12141
    pb_common.h                                    1980-01-01 00:00:00         1677
    pb_decode.c                                    1980-01-01 00:00:00        53759
    pb_decode.h                                    1980-01-01 00:00:00         7378
    pb_encode.c                                    1980-01-01 00:00:00        30339
    pb_encode.h                                    1980-01-01 00:00:00         6958
    nanopb-0.4.9.dev1465.dist-info/METADATA        1980-01-01 00:00:00         5848
    nanopb-0.4.9.dev1465.dist-info/WHEEL           1980-01-01 00:00:00           92
    nanopb-0.4.9.dev1465.dist-info/entry_points.txt 1980-01-01 00:00:00          143
    nanopb-0.4.9.dev1465.dist-info/RECORD          2016-01-01 00:00:00         2430