### PR TITLE
Prefer `generator/protoc` in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
 
 set(nanopb_PYTHON_INSTDIR_OVERRIDE "" CACHE PATH "Override the default python installation directory with the given path")
 
-find_program(nanopb_PROTOC_PATH protoc HINTS generator-bin generator)
+find_program(nanopb_PROTOC_PATH protoc PATHS generator-bin generator NO_DEFAULT_PATH)
+find_program(nanopb_PROTOC_PATH protoc)
 if(NOT EXISTS ${nanopb_PROTOC_PATH})
     message(FATAL_ERROR "protoc compiler not found")
 endif()

--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -407,7 +407,7 @@ add_library(nanopb STATIC EXCLUDE_FROM_ALL ${NANOPB_SRCS})
 target_compile_features(nanopb PUBLIC c_std_11)
 target_include_directories(nanopb PUBLIC ${NANOPB_INCLUDE_DIRS})
 
-# Find the protoc Executable
+# Find the local protoc Executable
 find_program(PROTOBUF_PROTOC_EXECUTABLE
     NAMES protoc
     DOC "The Google Protocol Buffers Compiler"
@@ -416,7 +416,25 @@ find_program(PROTOBUF_PROTOC_EXECUTABLE
     ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/Debug
     ${NANOPB_SRC_ROOT_FOLDER}/generator-bin
     ${NANOPB_SRC_ROOT_FOLDER}/generator
+    NO_DEFAULT_PATH
 )
+
+# Test protoc, try to get version
+execute_process(
+    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --version
+    OUTPUT_QUIET
+    ERROR_QUIET
+    RESULT_VARIABLE ret
+)
+if(NOT ret EQUAL 0)
+    # Fallback to system protoc
+    unset(PROTOBUF_PROTOC_EXECUTABLE)
+    find_program(PROTOBUF_PROTOC_EXECUTABLE
+        NAMES protoc
+        DOC "The Google Protocol Buffers Compiler"
+    )
+endif()
+
 mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
 
 # Find nanopb generator source dir

--- a/generator/proto/__init__.py
+++ b/generator/proto/__init__.py
@@ -67,14 +67,11 @@ def load_nanopb_pb2():
     # If the value of the $NANOPB_PB2_TEMP_DIR exists as a directory, it is used instead
     # of system temp folder.
 
-    build_error = None
-    proto_ok = False
     tmpdir = os.getenv("NANOPB_PB2_TEMP_DIR")
     temporary_only = (tmpdir is not None)
     dirname = os.path.dirname(__file__)
     protosrc = os.path.join(dirname, "nanopb.proto")
     protodst = os.path.join(dirname, "nanopb_pb2.py")
-    proto_ok = False
 
     if tmpdir is not None and not os.path.isdir(tmpdir):
         tmpdir = None # Use system-wide temp dir
@@ -84,16 +81,14 @@ def load_nanopb_pb2():
         # Don't attempt to autogenerate nanopb_pb2.py, external build rules
         # should have already done so.
         import nanopb_pb2 as nanopb_pb2_mod
-        proto_ok = True
-    elif os.path.isfile(protosrc):
+        return nanopb_pb2_mod
+
+    if os.path.isfile(protosrc):
         src_date = os.path.getmtime(protosrc)
-        if not os.path.isfile(protodst) or os.path.getmtime(protodst) < src_date:
-            # Outdated, rebuild
-            proto_ok = False
-        else:
+        if os.path.isfile(protodst) and os.path.getmtime(protodst) >= src_date:
             try:
                 from . import nanopb_pb2 as nanopb_pb2_mod
-                proto_ok = True
+                return nanopb_pb2_mod
             except Exception as e:
                 sys.stderr.write("Failed to import nanopb_pb2.py: " + str(e) + "\n"
                                 "Will automatically attempt to rebuild this.\n"
@@ -101,34 +96,33 @@ def load_nanopb_pb2():
                 print_versions()
 
     # Try to rebuild into generator/proto directory
-    if not proto_ok and not temporary_only:
-        proto_ok = build_nanopb_proto(protosrc, dirname)
+    if not temporary_only:
+        build_nanopb_proto(protosrc, dirname)
 
         try:
             from . import nanopb_pb2 as nanopb_pb2_mod
+            return nanopb_pb2_mod
         except:
             sys.stderr.write("Failed to import generator/proto/nanopb_pb2.py:\n")
             sys.stderr.write(traceback.format_exc() + "\n")
 
     # Try to rebuild into temporary directory
-    if not proto_ok:
-        with TemporaryDirectory(prefix = 'nanopb-', dir = tmpdir) as protodir:
-            proto_ok = build_nanopb_proto(protosrc, protodir)
+    with TemporaryDirectory(prefix = 'nanopb-', dir = tmpdir) as protodir:
+        build_nanopb_proto(protosrc, protodir)
 
-            if protodir not in sys.path:
-                sys.path.insert(0, protodir)
+        if protodir not in sys.path:
+            sys.path.insert(0, protodir)
 
-            try:
-                import nanopb_pb2 as nanopb_pb2_mod
-            except:
-                sys.stderr.write("Failed to import %s/nanopb_pb2.py:\n" % protodir)
-                sys.stderr.write(traceback.format_exc() + "\n")
+        try:
+            import nanopb_pb2 as nanopb_pb2_mod
+            return nanopb_pb2_mod
+        except:
+            sys.stderr.write("Failed to import %s/nanopb_pb2.py:\n" % protodir)
+            sys.stderr.write(traceback.format_exc() + "\n")
 
     # If everything fails
-    if not proto_ok:
-        sys.stderr.write("\n\nGenerating nanopb_pb2.py failed.\n")
-        sys.stderr.write("Make sure that a protoc generator is available and matches python-protobuf version.\n")
-        print_versions()
-        sys.exit(1)
+    sys.stderr.write("\n\nGenerating nanopb_pb2.py failed.\n")
+    sys.stderr.write("Make sure that a protoc generator is available and matches python-protobuf version.\n")
+    print_versions()
+    sys.exit(1)
 
-    return nanopb_pb2_mod


### PR DESCRIPTION
When building with CMake we should prefer to use the `protoc` executable that uses grpcio-tools.

Fixes #953