### PR TITLE
Do not include system paths when finding generator script

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -443,6 +443,7 @@ find_path(NANOPB_GENERATOR_SOURCE_DIR
     DOC "nanopb generator source"
     PATHS
     ${NANOPB_SRC_ROOT_FOLDER}/generator
+    NO_DEFAULT_PATH
     NO_CMAKE_FIND_ROOT_PATH
 )
 mark_as_advanced(NANOPB_GENERATOR_SOURCE_DIR)


### PR DESCRIPTION
Similar to searching for the local `protoc`, we should use the local `nanopb_generator.py` script.

The issue was reported at https://github.com/zephyrproject-rtos/zephyr/issues/70065#issuecomment-2133261857