### PR TITLE
Fix source tree paths with spaces

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -292,6 +292,9 @@ function(NANOPB_GENERATE_CPP)
         set(NANOPB_PLUGIN_OPTIONS "${NANOPB_PLUGIN_OPTIONS} -I${options_path}")
     endforeach()
 
+    # Remove leading space before the first -I directive
+    string(STRIP ${NANOPB_PLUGIN_OPTIONS} NANOPB_PLUGIN_OPTIONS)
+
     if(NANOPB_OPTIONS)
         set(NANOPB_PLUGIN_OPTIONS "${NANOPB_PLUGIN_OPTIONS} ${NANOPB_OPTIONS}")
     endif()


### PR DESCRIPTION
# Summary
Fix nanopb failure to take into account the `*.options` files when using CMake if the path to the source tree contains spaces.

The bug is due to an extra space between `--nanopb_opt=` and the first `-I` in `NANOPB_PLUGIN_OPTIONS` (no idea why it matters here).

# How to test
1. Clone and build the test example:
```sh
git clone https://github.com/gsurkov/nanopb-test.git --recursive "path with spaces"
cd path\ with\ spaces
mkdir && cd build
cmake .. && cmake --build .
```

2. Check the output files:
```sh
cat test.pb.h
```
The test struct will be defined as
```c
/* Struct definitions */
typedef struct _Test_Test {
    pb_callback_t test;
} Test_Test;
```
which is incorrect, as the `test` field is defined as `FT_POINTER` in the options file.

3. Checkout the branch containing the fix and rebuild everything:
```sh
git checkout spaces_in_path_fix
git subomodule update
cmake --build .
```

4. Check the output files again:
```sh
cat test.pb.h
```
Now it should read something like:
```c
/* Struct definitions */
typedef struct _Test_Test {
    char *test;
} Test_Test;
```
which is the intended code.

## System tested on
- OS: Linux 6.9.3
- CMake: 3.29.5
- Python: 3.12.3
- Protoc: 25.3