### PR TITLE
Surround NANOPB_PLUGIN_OPTIONS with quotation marks

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -293,7 +293,7 @@ function(NANOPB_GENERATE_CPP)
     endforeach()
 
     # Remove leading space before the first -I directive
-    string(STRIP ${NANOPB_PLUGIN_OPTIONS} NANOPB_PLUGIN_OPTIONS)
+    string(STRIP "${NANOPB_PLUGIN_OPTIONS}" NANOPB_PLUGIN_OPTIONS)
 
     if(NANOPB_OPTIONS)
         set(NANOPB_PLUGIN_OPTIONS "${NANOPB_PLUGIN_OPTIONS} ${NANOPB_OPTIONS}")


### PR DESCRIPTION
# Summary
Surround the `NANOPB_PLUGIN_OPTIONS` with quotation marks to make it expand properly into an empty string.

# How to test
Same as #971 