### PR TITLE
Set project() version correctly to avoid CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14.0)
 
-project(nanopb C)
+project(nanopb VERSION 0.4.9 LANGUAGES C)
 
-set(nanopb_VERSION_STRING nanopb-0.4.9-dev)
+set(nanopb_VERSION_STRING ${PROJECT_NAME}-${${PROJECT_NAME}_VERSION}-dev)
 set(nanopb_SOVERSION 0)
 
 string(REPLACE "nanopb-" "" nanopb_VERSION ${nanopb_VERSION_STRING})

--- a/tools/set_version.sh
+++ b/tools/set_version.sh
@@ -4,9 +4,10 @@
 # e.g. user@localhost:~/nanopb$ tools/set_version.sh nanopb-0.1.9-dev
 # It sets the version number in pb.h and generator/nanopb_generator.py.
 
+VERSION_NUMBER_ONLY=$(echo $1 | cut -d '-' -f 2)
 sed -i -e 's/nanopb_version\s*=\s*"[^"]*"/nanopb_version = "'$1'"/' generator/nanopb_generator.py
 sed -i -e 's/#define\s*NANOPB_VERSION\s*.*/#define NANOPB_VERSION "'$1'"/' pb.h
-sed -i -e 's/set(\s*nanopb_VERSION_STRING\s*[^)]*)/set(nanopb_VERSION_STRING '$1')/' CMakeLists.txt
+sed -i -e 's/project(\s*nanopb\s*VERSION\s*[^)]*\s*LANGUAGES\s*C\s*)/project(nanopb VERSION '$VERSION_NUMBER_ONLY' LANGUAGES C)/' CMakeLists.txt
 
 VERSION_ONLY=$(echo $1 | sed 's/nanopb-//')
 if [[ $1 != *dev ]]


### PR DESCRIPTION
(Related to CMake warning: "policy CMP0048 is not set: project() command manages VERSION variables")