### PR TITLE
ci: binary_packages: add actions/setup-python

### DIFF
--- a/.github/workflows/binary_packages.yml
+++ b/.github/workflows/binary_packages.yml
@@ -21,6 +21,11 @@ jobs:
           path: nanopb
           fetch-depth: "0"
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
       - name: Install dependencies
         run: |
           python3 -m pip install --user --upgrade scons protobuf grpcio-tools pyinstaller


### PR DESCRIPTION
This *should* fix #972 , although I am not completely sure.

As I mentioned in https://github.com/nanopb/nanopb/issues/972#issuecomment-2236295006 this seems to be a really weird issue. My guess is that this is due to GitHub not correctly sanitizing the systems between jobs.

The problems I mentioned in #989 caused me problems with testing, but by running some jobs in a different branch, it seems that adding the `actions/setup-python@v5` action should do the trick.

I have had three jobs in a row succeed:

- https://github.com/jaskij/nanopb/actions/runs/9991129469/job/27613287656
- https://github.com/jaskij/nanopb/actions/runs/9991087641/job/27613159772
- https://github.com/jaskij/nanopb/actions/runs/9991020187/job/27612941035