### PR TITLE
generator: remove ifdef __cplusplus on enum sizes

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -439,9 +439,7 @@ class Enum(ProtoElement):
         # Override the enum size if user wants to use smaller integers
         if (FieldD.TYPE_ENUM, self.options.int_size) in datatypes:
             self.ctype, self.pbtype, self.enc_size, self.data_item_size = datatypes[(FieldD.TYPE_ENUM, self.options.int_size)]
-            result += '\n#ifdef __cplusplus\n'
             result += ' : ' + self.ctype + '\n'
-            result += '#endif\n'
             result += '{'
         else:
             result += ' {'


### PR DESCRIPTION
While this does not solve #961 completely, it will make the compiler error when sized enums are supported.

I experimented somewhat with adding a preprocessor check, but it seems that GCC extends enum sizes to older C standards, since the enum_sizes test passes without it and fails to compile when I add that.

Yup, seems like GCC extends this extension to all versions of C.

This will absolutely break some builds, but at least it will be broken builds instead of faulty software.