### PR TITLE
run binary_packages on Python 3.8, and on latest 3.x

### DIFF
--- a/.github/workflows/binary_packages.yml
+++ b/.github/workflows/binary_packages.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build_linux:
     name: Build binary on Ubuntu 20.04
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.8', '3.x']
+        os: ['ubuntu-20.04', 'ubuntu-24.04']
 
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/binary_packages.yml
+++ b/.github/workflows/binary_packages.yml
@@ -13,6 +13,9 @@ jobs:
   build_linux:
     name: Build binary on Ubuntu 20.04
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.x']
 
     steps:
       - name: Check out code from GitHub
@@ -24,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/binary_packages.yml
+++ b/.github/workflows/binary_packages.yml
@@ -12,11 +12,7 @@ on:
 jobs:
   build_linux:
     name: Build binary on Ubuntu 20.04
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.x']
-        os: ['ubuntu-20.04', 'ubuntu-24.04']
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out code from GitHub
@@ -28,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/trigger_on_code_change.yml
+++ b/.github/workflows/trigger_on_code_change.yml
@@ -37,15 +37,17 @@ jobs:
         with:
           path: nanopb
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install python3-protobuf protobuf-compiler scons splint valgrind
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler splint valgrind
+          python3 -m pip install --user --upgrade scons protobuf grpcio-tools pyinstaller
+          python3 -c 'import google.protobuf; print(google.protobuf.__file__)'
 
       - name: Run tests
         run: |

--- a/.github/workflows/trigger_on_code_change.yml
+++ b/.github/workflows/trigger_on_code_change.yml
@@ -25,7 +25,11 @@ on:
 jobs:
   smoke_test:
     name: Run test suite on Ubuntu 20.04
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.x']
+        os: ['ubuntu-20.04', 'ubuntu-24.04']
 
     steps:
       - name: Check out code from GitHub
@@ -37,6 +41,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install python3-protobuf protobuf-compiler scons splint valgrind
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Run tests
         run: |

--- a/generator/proto/__init__.py
+++ b/generator/proto/__init__.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 import shutil
 import traceback
-import pkg_resources
 from ._utils import has_grpcio_protoc, invoke_protoc, print_versions
 
 # Compatibility layer to make TemporaryDirectory() available on Python 2.
@@ -42,8 +41,7 @@ def build_nanopb_proto(protosrc, dirname):
     if has_grpcio_protoc():
         # grpcio-tools has an extra CLI argument
         # from grpc.tools.protoc __main__ invocation.
-        _builtin_proto_include = pkg_resources.resource_filename('grpc_tools', '_proto')
-        cmd.append("-I={}".format(_builtin_proto_include))
+        cmd.append("-I={}".format(_utils.get_grpc_tools_proto_path()))
 
     try:
         invoke_protoc(argv=cmd)

--- a/generator/proto/_utils.py
+++ b/generator/proto/_utils.py
@@ -17,6 +17,15 @@ def has_grpcio_protoc(verbose = False):
 
     return True
 
+def get_grpc_tools_proto_path():
+    if sys.hexversion > 0x03090000:
+        import importlib.resources as ir
+        with ir.as_file(ir.files('grpc_tools') / '_proto') as path:
+            return str(path)
+    else:
+        import pkg_resources
+        return pkg_resources.resource_filename('grpc_tools', '_proto')
+
 def get_proto_builtin_include_path():
     """Find include path for standard google/protobuf includes and for
     nanopb.proto.
@@ -36,8 +45,7 @@ def get_proto_builtin_include_path():
         ]
 
         if has_grpcio_protoc():
-            import pkg_resources
-            paths.append(pkg_resources.resource_filename('grpc_tools', '_proto'))
+            paths.append(get_grpc_tools_proto_path())
 
     return paths
 


### PR DESCRIPTION
Due to #887 , it occurred to me it may be a good idea to test on the latest version of Python as well, among others to get early warnings of deprecations.