### PR TITLE
Remove pkg resources

### DIFF
--- a/.github/workflows/trigger_on_code_change.yml
+++ b/.github/workflows/trigger_on_code_change.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Check for pkg_resources
         run: |
-          ! grep -RniI pkg_resources nanopb/generator
+          cd nanopb
+          ./check_pkg_resources.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/trigger_on_code_change.yml
+++ b/.github/workflows/trigger_on_code_change.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           path: nanopb
 
+      - name: Check for pkg_resources
+        run: |
+          ! grep -RniI pkg_resources nanopb/generator
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/check_pkg_resources.sh
+++ b/check_pkg_resources.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+[[ $(grep -RiIc pkg_resources generator | cut -d':' -f2 | paste -sd+ | bc) == 2 ]]
+

--- a/generator/proto/__init__.py
+++ b/generator/proto/__init__.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 import shutil
 import traceback
-import pkg_resources
 from ._utils import has_grpcio_protoc, invoke_protoc, print_versions
 
 # Compatibility layer to make TemporaryDirectory() available on Python 2.
@@ -42,8 +41,7 @@ def build_nanopb_proto(protosrc, dirname):
     if has_grpcio_protoc():
         # grpcio-tools has an extra CLI argument
         # from grpc.tools.protoc __main__ invocation.
-        _builtin_proto_include = pkg_resources.resource_filename('grpc_tools', '_proto')
-        cmd.append("-I={}".format(_builtin_proto_include))
+        cmd.append("-I={}".format(_utils.get_grpc_tools_proto_path()))
 
     try:
         invoke_protoc(argv=cmd)

--- a/generator/proto/_utils.py
+++ b/generator/proto/_utils.py
@@ -17,6 +17,15 @@ def has_grpcio_protoc(verbose = False):
 
     return True
 
+def get_grpc_tools_proto_path():
+    if sys.hexversion > 0x03090000:
+        import importlib.resources as ir
+        with ir.as_file(ir.files('grpc_tools') / '_proto') as path:
+            return str(path)
+    else:
+        import pkg_resources
+        return pkg_resources.resource_filename('grpc_tools', '_proto')
+
 def get_proto_builtin_include_path():
     """Find include path for standard google/protobuf includes and for
     nanopb.proto.
@@ -36,8 +45,7 @@ def get_proto_builtin_include_path():
         ]
 
         if has_grpcio_protoc():
-            import pkg_resources
-            paths.append(pkg_resources.resource_filename('grpc_tools', '_proto'))
+            paths.append(get_grpc_tools_proto_path())
 
     return paths
 


### PR DESCRIPTION
Disclaimer: I'm not familiar enough with Python to know that the changes I made are actually good. The tests past locally for me.

What this change does is abstract the two existing uses of `pkg_resources` into a single function, and inside it only uses that if Python is in version 3.8 or older.

The other option, which I didn't want to do, was to add a new dependency on [`importlib_resources`](https://pypi.org/project/importlib-resources/) for older Python versions.

3.9 is the cutoff, since it introduces the `importlib.resources` APIs this code used.

I also added a small script, `check_pkg_resources.sh`, which is a Bash one liner that checks there are exactly two instances of `pkg_resources` in all non-binary files under `generator/`.