### PR TITLE
Fix Comment position with optional is used.

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -774,7 +774,7 @@ class Field(ProtoElement):
         var_name = Globals.naming_style.var_name(self.name)
         type_name = Globals.naming_style.type_name(self.ctype) if isinstance(self.ctype, Names) else self.ctype
         leading_comment, trailing_comment = self.get_comments(leading_indent = True)
-
+        leading_comment_written = False
         if self.allocation == 'POINTER':
             if self.rules == 'REPEATED':
                 if self.pbtype == 'MSG_W_CB':
@@ -796,7 +796,6 @@ class Field(ProtoElement):
             else:
                 # Normal case, just a pointer to single item
                 result += '    %s *%s;' % (type_name, var_name)
-            if leading_comment: result = leading_comment + "\n" + result
         elif self.allocation == 'CALLBACK':
             result += '    %s %s;' % (self.callback_datatype, var_name)
             if leading_comment: result = leading_comment + "\n" + result
@@ -808,10 +807,13 @@ class Field(ProtoElement):
                 result += '    bool has_' + var_name + ';\n'
             elif self.rules == 'REPEATED':
                 result += '    pb_size_t ' + var_name + '_count;\n'
-            if leading_comment: result = result + leading_comment + "\n"
+            if leading_comment: 
+                result = result + leading_comment + "\n"
+                leading_comment_written = True
             result += '    %s %s%s;' % (type_name, var_name, self.array_decl)
 
         leading_comment, trailing_comment = self.get_comments(leading_indent = True)
+        if leading_comment and leading_comment_written == False: result = leading_comment + "\n" + result
         if trailing_comment: result = result + " " + trailing_comment
 
         return result

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -773,6 +773,7 @@ class Field(ProtoElement):
 
         var_name = Globals.naming_style.var_name(self.name)
         type_name = Globals.naming_style.type_name(self.ctype) if isinstance(self.ctype, Names) else self.ctype
+        leading_comment, trailing_comment = self.get_comments(leading_indent = True)
 
         if self.allocation == 'POINTER':
             if self.rules == 'REPEATED':
@@ -795,8 +796,10 @@ class Field(ProtoElement):
             else:
                 # Normal case, just a pointer to single item
                 result += '    %s *%s;' % (type_name, var_name)
+            if leading_comment: result = leading_comment + "\n" + result
         elif self.allocation == 'CALLBACK':
             result += '    %s %s;' % (self.callback_datatype, var_name)
+            if leading_comment: result = leading_comment + "\n" + result
         else:
             if self.pbtype == 'MSG_W_CB' and self.rules in ['OPTIONAL', 'REPEATED']:
                 result += '    pb_callback_t cb_' + var_name + ';\n'
@@ -805,11 +808,10 @@ class Field(ProtoElement):
                 result += '    bool has_' + var_name + ';\n'
             elif self.rules == 'REPEATED':
                 result += '    pb_size_t ' + var_name + '_count;\n'
-
+            if leading_comment: result = result + leading_comment + "\n"
             result += '    %s %s%s;' % (type_name, var_name, self.array_decl)
 
         leading_comment, trailing_comment = self.get_comments(leading_indent = True)
-        if leading_comment: result = leading_comment + "\n" + result
         if trailing_comment: result = result + " " + trailing_comment
 
         return result

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -798,7 +798,6 @@ class Field(ProtoElement):
                 result += '    %s *%s;' % (type_name, var_name)
         elif self.allocation == 'CALLBACK':
             result += '    %s %s;' % (self.callback_datatype, var_name)
-            if leading_comment: result = leading_comment + "\n" + result
         else:
             if self.pbtype == 'MSG_W_CB' and self.rules in ['OPTIONAL', 'REPEATED']:
                 result += '    pb_callback_t cb_' + var_name + ';\n'


### PR DESCRIPTION
If a field is optional and has a leading comment, leading comment is written before "has_field".

```proto
message Sample {
  // Comment
  optional int32value = 1;
}
```

```c
typedef struct _SampleMessage {
    /* Comment*/
    bool has_value;
    int32_t value;
} SampleMessage ;
```

In this condition, Intellisense comment of VS code is shown on has_value field.
With this change, comment position is on appropriate position as shown below.

```c
typedef struct _SampleMessage {
    bool has_value;
    /* Comment*/
    int32_t value;
} SampleMessage ;
```