### PR TITLE
Replace deprecated call to protobuf.reflection.MakeClass()

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -34,8 +34,8 @@ try:
     import google.protobuf.text_format as text_format
     import google.protobuf.descriptor_pb2 as descriptor
     import google.protobuf.compiler.plugin_pb2 as plugin_pb2
-    import google.protobuf.reflection as reflection
     import google.protobuf.descriptor
+    import google.protobuf.message_factory as message_factory
 except:
     sys.stderr.write('''
          **********************************************************************
@@ -1689,7 +1689,7 @@ class Message(ProtoElement):
         optional_only.name += str(id(self))
 
         desc = google.protobuf.descriptor.MakeDescriptor(optional_only)
-        msg = reflection.MakeClass(desc)()
+        msg = message_factory.GetMessageClass(desc)()
 
         for field in optional_only.field:
             if field.type == FieldD.TYPE_STRING:


### PR DESCRIPTION
Protobuf's MakeClass() function has been deprecated. According to [the source code](https://github.com/protocolbuffers/protobuf/blob/95ef4134d3f65237b7adfb66e5e7aa10fcfa1fa3/python/google/protobuf/reflection.py#L66C1-L66C4) it will be removed in Jan 2025.

Building C files with nanopb calls the deprecated function, and throws a warning on my machine when using the pip protobuf package v5.28.1.

This PR replaces the function call with the one recommended in the the source code.