### PR TITLE
Various stack size reduction tweaks

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -28,6 +28,9 @@
 /* Disable support for error messages in order to save some code space. */
 /* #define PB_NO_ERRMSG 1 */
 
+/* Disable checks to ensure sub-message encoded size is consistent when re-run. */
+/* #define PB_NO_ENCODE_SIZE_CHECK 1 */
+
 /* Disable support for custom streams (support only memory buffers). */
 /* #define PB_BUFFER_ONLY 1 */
 
@@ -124,6 +127,19 @@ extern "C" {
 #   define PB_PACKED_STRUCT_START
 #   define PB_PACKED_STRUCT_END
 #   define pb_packed
+#endif
+
+/* Define for explicitly not inlining a given function */
+#if defined(__GNUC__) || defined(__clang__)
+    /* For GCC and clang */
+#   define pb_noinline __attribute__((noinline))
+#elif defined(__ICCARM__) || defined(__CC_ARM)
+    /* For IAR ARM and Keil MDK-ARM compilers */
+#   define pb_noinline
+#elif defined(_MSC_VER) && (_MSC_VER >= 1500)
+#   define pb_noinline __declspec(noinline)
+#else
+#   define pb_noinline
 #endif
 
 /* Detect endianness */


### PR DESCRIPTION
As part of my work integrating nanopb into ZMK (by way of the Zephyr integration), like many others I've been hit with some high stack usage. The attached changes helped drop the usage by about 300bytes with my testing. The current ZMK PR integrating this change is up at https://github.com/zmkfirmware/zmk/pull/2505

* Add option for skipping size checks when encoding submessages
* Tweak inline/noinline for functions to reduce stack size.

Not sure if this is something you'd be interested in, but I wanted to at least propose upstream here. Thanks for the project!