### PR TITLE
Fix inner enum naming with a default value

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -881,6 +881,8 @@ class Field(ProtoElement):
                     inner_init += '.0f'
                 elif self.pbtype == 'FLOAT':
                     inner_init += 'f'
+            elif self.pbtype in ('ENUM', 'UENUM'):
+                inner_init = Globals.naming_style.enum_entry(self.default)
             else:
                 inner_init = str(self.default)
 

--- a/tests/namingstyle/naming_style.proto
+++ b/tests/namingstyle/naming_style.proto
@@ -24,6 +24,7 @@ message MainMessage {
   optional MY_ENUM2   My_Enum2        = 6;
   required MY_ENUM2   MY_ENUM3        = 7;
   repeated MY_ENUM2   MY_ENUM4        = 8;
+  required MyEnum1    MyEnum5         = 25 [default = ENTRY_Second];
 
   repeated string     string_Values1  = 9;
   repeated string     stringValues2   = 10;

--- a/tests/namingstyle/test_naming_style_c.c
+++ b/tests/namingstyle/test_naming_style_c.c
@@ -10,7 +10,11 @@
 int main()
 {
     int status = 0;
+    main_message_t defaultMessage = MAIN_MESSAGE_INIT_DEFAULT;
     main_message_t message = MAIN_MESSAGE_INIT_ZERO;
+
+    /* Verify the default value was initialized */
+    TEST(defaultMessage.my_enum5 == MY_ENUM1_ENTRY_SECOND);
 
     /* Verify that all members have the expected names */
     message.lucky_number = 13;


### PR DESCRIPTION
Fixes #1014 

The first commit adds a test that fails because it generates an undeclared identifier `MyEnum1_ENTRY_Second` in `MAIN_MESSAGE_INIT_DEFAULT` instead of the expected `MY_ENUM1_ENTRY_SECOND`. The second commit fixes it by utilizing the configured naming style for enum values. 

## Simple Example

Given the following _test.proto_ file:

```protobuf
syntax = "proto2";

enum MyEnum {
    ValueOne = 1;
    ValueTwo = 2;
}

message Msg {
    required MyEnum enum = 1 [default = ValueOne];
}
```

Running `python3 nanopb_generator.py --c-style` would previously result in the following _test.pb.h_ (only relevant definitions included):

```c
/* Enum definitions */
typedef enum my_enum {
    MY_ENUM_VALUE_ONE = 1,
    MY_ENUM_VALUE_TWO = 2
} my_enum_t;

/* Initializer values for message structs */
#define MSG_INIT_DEFAULT                         {MyEnum_ValueOne}
```

Not the mismatch between `MY_ENUM_VALUE_ONE` and `MyEnum_ValueOne` in the default initializer.

With this PR, the output is correctly now:

```c
/* Initializer values for message structs */
#define MSG_INIT_DEFAULT                         {MY_ENUM_VALUE_ONE}
```