### PR TITLE
Add cases for `PB_WT_PACKED`

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -313,6 +313,11 @@ bool checkreturn pb_skip_field(pb_istream_t *stream, pb_wire_type_t wire_type)
         case PB_WT_64BIT: return pb_read(stream, NULL, 8);
         case PB_WT_STRING: return pb_skip_string(stream);
         case PB_WT_32BIT: return pb_read(stream, NULL, 4);
+	case PB_WT_PACKED: 
+            /* Calling pb_skip_field with a PB_WT_PACKED is an error.
+             * Explicitly handle this case and fallthrough to default to avoid
+             * compiler warnings.
+             */
         default: PB_RETURN_ERROR(stream, "invalid wire_type");
     }
 }
@@ -348,6 +353,12 @@ static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire
         
         case PB_WT_STRING:
             /* Calling read_raw_value with a PB_WT_STRING is an error.
+             * Explicitly handle this case and fallthrough to default to avoid
+             * compiler warnings.
+             */
+
+	case PB_WT_PACKED: 
+            /* Calling read_raw_value with a PB_WT_PACKED is an error.
              * Explicitly handle this case and fallthrough to default to avoid
              * compiler warnings.
              */


### PR DESCRIPTION
```
nanopb/pb_decode.c:309:5: warning: enumeration value 'PB_WT_PACKED' not handled in switch [-Wswitch-enum]
  309 |     switch (wire_type)
      |     ^~~~~~
nanopb/pb_decode.c: In function 'read_raw_value':
nanopb/pb_decode.c:325:5: warning: enumeration value 'PB_WT_PACKED' not handled in switch [-Wswitch-enum]
  325 |     switch (wire_type)
      |     ^~~~~~
```

To get rid of this warning, adds cases in `pb_decode.c` for the `PB_WT_PACKED` wire type. In `pb.h`, it's states it is an internal marker for arrays and I assume an invalid wire type. Treating it as such in the switch/case