### PR TITLE
Support custom naming styles

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -166,6 +166,7 @@ There are also a few command line options that cannot be applied using the
 other mechanisms, as they affect the whole generation:
 
 * `--c-style`: Modify symbol names to better match C naming conventions.
+* `--custom-style`: Modify symbol names by providing your own styler implementation.
 * `--no-timestamp`: Do not add timestamp to generated files.
 * `--strip-path`: Remove relative path from generated `#include` directives.
 * `--cpp-descriptors`: Generate extra convenience definitions for use from C++
@@ -224,6 +225,12 @@ For a full list of generator command line options, use `nanopb_generator.py --he
                             Include insertion point comments in output for use by
                             custom protoc plugins
     -C, --c-style         Use C naming convention.
+    --custom-style=MODULE.CLASS
+                          Use a custom naming convention from a module/class
+                          that defines the methods from the NamingStyle class to
+                          be overridden. When paired with the -C/--c-style
+                          option, the NamingStyleC class is the fallback,
+                          otherwise it's the NamingStyle class.
 
     Compile file.pb from file.proto by: 'protoc -ofile.pb file.proto'. Output will
     be written to file.pb.h and file.pb.c.

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -535,11 +535,10 @@ class Enum(ProtoElement):
         result += '    switch (v) {\n'
 
         for ((enumname, _), strname) in zip(self.values, self.value_longnames):
-            # Strip off the leading type name from the string value.
-            strval = str(strname)[len(str(self.names)) + 1:]
+            # Just use the last part of the string value.
             result += '        case %s: return "%s";\n' % (
                 Globals.naming_style.enum_entry(enumname),
-                Globals.naming_style.enum_entry(strval))
+                Globals.naming_style.enum_entry(strname.parts[-1]))
 
         result += '    }\n'
         result += '    return "unknown";\n'

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -813,7 +813,7 @@ class Field(ProtoElement):
     def types(self):
         '''Return definitions for any special types this field might need.'''
         if self.pbtype == 'BYTES' and self.allocation == 'STATIC':
-            result = 'typedef PB_BYTES_ARRAY_T(%d) %s;\n' % (self.max_size, Globals.naming_style.var_name(self.ctype))
+            result = 'typedef PB_BYTES_ARRAY_T(%d) %s;\n' % (self.max_size, self.ctype)
         else:
             result = ''
         return result

--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1172,7 +1172,7 @@ class ExtensionField(Field):
         result = "/* Definition for extension field %s */\n" % self.fullname
         result += str(self.msg)
         result += self.msg.fields_declaration(dependencies)
-        result += 'pb_byte_t %s_default[] = {0x00};\n' % self.msg.name
+        result += 'pb_byte_t %s_default[] = {0x00};\n' % Globals.naming_style.var_name(self.msg.name)
         result += self.msg.fields_definition(dependencies)
         result += 'const pb_extension_type_t %s = {\n' % Globals.naming_style.var_name(self.fullname)
         result += '    NULL,\n'

--- a/tests/namingstyle_custom/SConscript
+++ b/tests/namingstyle_custom/SConscript
@@ -1,0 +1,23 @@
+# Test namingstyle option
+
+Import('env')
+
+env = env.Clone()
+env.Replace(NANOPBFLAGS = "--custom-style=custom_naming_style.CustomNamingStyle")
+
+style = Command("custom_naming_style.py", "../../namingstyle_custom/custom_naming_style.py", Copy("$TARGET", "$SOURCE"))
+
+proto = env.NanopbProto(["custom_naming_style", "custom_naming_style.options"])
+Depends(proto, style)
+proto = env.NanopbProto(["custom_naming_style_package", "custom_naming_style_package.options"])
+Depends(proto, style)
+proto = env.NanopbProto(["custom_naming_style_mangle", "custom_naming_style_mangle.options"])
+Depends(proto, style)
+
+test = env.Program(["test_custom_naming_style_c.c", "custom_naming_style.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+mangle = env.Program(["test_custom_naming_style_mangle_c.c", "custom_naming_style_mangle.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+package = env.Program(["test_custom_naming_style_package_c.c", "custom_naming_style_package.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+
+env.RunTest(test)
+env.RunTest(mangle)
+env.RunTest(package)

--- a/tests/namingstyle_custom/custom_naming_style.options
+++ b/tests/namingstyle_custom/custom_naming_style.options
@@ -1,0 +1,16 @@
+* long_names:true
+* enum_to_string:true
+* enum_validate:true
+
+MainMessage.repeatedNumber  max_count:4, fixed_count:true
+MainMessage.string_Values1  type:FT_POINTER
+MainMessage.stringValues2   max_length:40, max_count:5
+MainMessage.requiredString  max_length:10
+MainMessage.repeatedFixed32 max_count:10
+MainMessage.requiredBytes1  max_size:10, fixed_length:true
+MainMessage.requiredBytes2  max_size:10
+MainMessage.repeatedBytes1  type:FT_POINTER
+MainMessage.repeatedBytes2  type:FT_POINTER, fixed_count:true, max_count:5
+MainMessage.repeatedInts    type:FT_POINTER
+MainMessage.SUB_MESSAGE2    type:FT_CALLBACK
+MainMessage.oneOfName2      anonymous_oneof:true

--- a/tests/namingstyle_custom/custom_naming_style.proto
+++ b/tests/namingstyle_custom/custom_naming_style.proto
@@ -1,0 +1,69 @@
+// Copied from
+syntax = "proto2";
+
+enum MyEnum1 {
+  ENTRY_FIRST   = 0;
+  ENTRY_Second  = 1;
+  EnumThird     = 2;
+}
+
+enum MY_ENUM2 {
+  ENUM2_ENTRY = 0;
+}
+
+message SubMessage {
+  optional int32 test_value = 1;
+}
+
+message MainMessage {
+  optional int32      LUCKY_number    = 1;
+  required int32      REQUIRED_NUMBER = 2;
+  repeated int32      repeatedNumber  = 3;
+  repeated int32      repeatedInts    = 4;
+
+  optional MyEnum1    MyEnum1         = 5;
+  optional MY_ENUM2   My_Enum2        = 6;
+  required MY_ENUM2   MY_ENUM3        = 7;
+  repeated MY_ENUM2   MY_ENUM4        = 8;
+  required MyEnum1    MyEnum5         = 25 [default = ENTRY_Second];
+  required InnerEnum  my_enum6        = 26;
+
+  repeated string     string_Values1  = 9;
+  repeated string     stringValues2   = 10;
+  optional string     OPTIONAL_String = 11;
+  required string     requiredString  = 12;
+
+  repeated fixed32    repeatedFixed32 = 13;
+
+  required bytes      requiredBytes1  = 14;
+  required bytes      requiredBytes2  = 15;
+  repeated bytes      repeatedBytes1  = 16;
+  repeated bytes      repeatedBytes2  = 17;
+
+  optional SubMessage subMessage1     = 18;
+  repeated SubMessage SUB_MESSAGE2    = 19;
+  required SubMessage sub_message3    = 20;
+
+  oneof oneOfName {
+    SubMessage testMessage1 = 21;
+    SubMessage testMessage2 = 22;
+  }
+
+  oneof oneOfName2 {
+    SubMessage testMessage4 = 23;
+    SubMessage testMessage5 = 24;
+  }
+
+  enum InnerEnum {
+    Inside = 0;
+  }
+
+  extensions 200 to 255;
+}
+
+message TestExtension {
+  extend MainMessage {
+      optional TestExtension testExtension = 250;
+  }
+  optional string stringValue = 1;
+}

--- a/tests/namingstyle_custom/custom_naming_style.py
+++ b/tests/namingstyle_custom/custom_naming_style.py
@@ -1,0 +1,53 @@
+import re
+
+
+class CustomNamingStyle:
+    """A custom C naming style which fewer delimiters."""
+
+    def struct_name(self, name):
+        return "_" + self._pascal_case(name)
+
+    def define_name(self, name):
+        return self._snake_case(name).upper()
+
+    def union_name(self, name):
+        return self.struct_name(name)
+
+    def enum_name(self, name):
+        return self.struct_name(name)
+
+    def enum_entry(self, name):
+        return self.define_name(name)
+
+    def var_name(self, name):
+        return self._camel_case(name)
+
+    def func_name(self, name):
+        return self.type_name(name)
+
+    def type_name(self, name):
+        return self._pascal_case(name)
+
+    def bytes_type(self, struct_name, name):
+        return self._pascal_case("%s_%s" % (struct_name, name)) + "_t"
+
+    def _pascal_case(self, name):
+        return self._snake_case(name).title().replace('_', '')
+
+    def _camel_case(self, name):
+        name = self._pascal_case(name)
+        return name[:1].lower() + name[1:]
+
+    def _snake_case(self, name):
+        name = str(name)
+
+        # Insert a boundary before the last uppercase letter in a series of uppercase letters if lowercase letters follow
+        name = re.sub(r"([A-Z]+)([A-Z][a-z])", r'\1_\2', name)
+
+        # Insert a boundary between lowercase letters followed by uppercase letters
+        name = re.sub(r"([a-z\d])([A-Z])", r'\1_\2', name)
+
+        # Replace all delimiters with underscores
+        name = re.sub(r"[_ -]+", "_", name)
+
+        return name.lower()

--- a/tests/namingstyle_custom/custom_naming_style_mangle.options
+++ b/tests/namingstyle_custom/custom_naming_style_mangle.options
@@ -1,0 +1,17 @@
+* mangle_names:M_STRIP_PACKAGE
+* long_names:true
+* enum_to_string:true
+* enum_validate:true
+
+MainMessage.repeatedNumber  max_count:4, fixed_count:true
+MainMessage.string_Values1  type:FT_POINTER
+MainMessage.stringValues2   max_length:40, max_count:5
+MainMessage.requiredString  max_length:10
+MainMessage.repeatedFixed32 max_count:10
+MainMessage.requiredBytes1  max_size:10, fixed_length:true
+MainMessage.requiredBytes2  max_size:10
+MainMessage.repeatedBytes1  type:FT_POINTER
+MainMessage.repeatedBytes2  type:FT_POINTER, fixed_count:true, max_count:5
+MainMessage.repeatedInts    type:FT_POINTER
+MainMessage.SUB_MESSAGE2    type:FT_CALLBACK
+MainMessage.oneOfName2      anonymous_oneof:true

--- a/tests/namingstyle_custom/custom_naming_style_mangle.proto
+++ b/tests/namingstyle_custom/custom_naming_style_mangle.proto
@@ -1,0 +1,70 @@
+syntax = "proto2";
+
+package package;
+
+enum MyEnum1 {
+  ENTRY_FIRST   = 0;
+  ENTRY_Second  = 1;
+  EnumThird     = 2;
+}
+
+enum MY_ENUM2 {
+  ENUM2_ENTRY = 0;
+}
+
+message SubMessage {
+  optional int32 test_value = 1;
+}
+
+message MainMessage {
+  optional int32      LUCKY_number    = 1;
+  required int32      REQUIRED_NUMBER = 2;
+  repeated int32      repeatedNumber  = 3;
+  repeated int32      repeatedInts    = 4;
+
+  optional MyEnum1    MyEnum1         = 5;
+  optional MY_ENUM2   My_Enum2        = 6;
+  required MY_ENUM2   MY_ENUM3        = 7;
+  repeated MY_ENUM2   MY_ENUM4        = 8;
+  required MyEnum1    MyEnum5         = 25 [default = ENTRY_Second];
+  required InnerEnum  my_enum6        = 26;
+
+  repeated string     string_Values1  = 9;
+  repeated string     stringValues2   = 10;
+  optional string     OPTIONAL_String = 11;
+  required string     requiredString  = 12;
+
+  repeated fixed32    repeatedFixed32 = 13;
+
+  required bytes      requiredBytes1  = 14;
+  required bytes      requiredBytes2  = 15;
+  repeated bytes      repeatedBytes1  = 16;
+  repeated bytes      repeatedBytes2  = 17;
+
+  optional SubMessage subMessage1     = 18;
+  repeated SubMessage SUB_MESSAGE2    = 19;
+  required SubMessage sub_message3    = 20;
+
+  oneof oneOfName {
+    SubMessage testMessage1 = 21;
+    SubMessage testMessage2 = 22;
+  }
+
+  oneof oneOfName2 {
+    SubMessage testMessage4 = 23;
+    SubMessage testMessage5 = 24;
+  }
+
+  enum InnerEnum {
+    Inside = 0;
+  }
+
+  extensions 200 to 255;
+}
+
+message TestExtension {
+  extend MainMessage {
+      optional TestExtension testExtension = 250;
+  }
+  optional string stringValue = 1;
+}

--- a/tests/namingstyle_custom/custom_naming_style_package.options
+++ b/tests/namingstyle_custom/custom_naming_style_package.options
@@ -1,0 +1,16 @@
+* long_names:true
+* enum_to_string:true
+* enum_validate:true
+
+package.MainMessage.repeatedNumber  max_count:4, fixed_count:true
+package.MainMessage.string_Values1  type:FT_POINTER
+package.MainMessage.stringValues2   max_length:40, max_count:5
+package.MainMessage.requiredString  max_length:10
+package.MainMessage.repeatedFixed32 max_count:10
+package.MainMessage.requiredBytes1  max_size:10, fixed_length:true
+package.MainMessage.requiredBytes2  max_size:10
+package.MainMessage.repeatedBytes1  type:FT_POINTER
+package.MainMessage.repeatedBytes2  type:FT_POINTER, fixed_count:true, max_count:5
+package.MainMessage.repeatedInts    type:FT_POINTER
+package.MainMessage.SUB_MESSAGE2    type:FT_CALLBACK
+package.MainMessage.oneOfName2      anonymous_oneof:true

--- a/tests/namingstyle_custom/custom_naming_style_package.proto
+++ b/tests/namingstyle_custom/custom_naming_style_package.proto
@@ -1,0 +1,70 @@
+syntax = "proto2";
+
+package package;
+
+enum MyEnum1 {
+  ENTRY_FIRST   = 0;
+  ENTRY_Second  = 1;
+  EnumThird     = 2;
+}
+
+enum MY_ENUM2 {
+  ENUM2_ENTRY = 0;
+}
+
+message SubMessage {
+  optional int32 test_value = 1;
+}
+
+message MainMessage {
+  optional int32      LUCKY_number    = 1;
+  required int32      REQUIRED_NUMBER = 2;
+  repeated int32      repeatedNumber  = 3;
+  repeated int32      repeatedInts    = 4;
+
+  optional MyEnum1    MyEnum1         = 5;
+  optional MY_ENUM2   My_Enum2        = 6;
+  required MY_ENUM2   MY_ENUM3        = 7;
+  repeated MY_ENUM2   MY_ENUM4        = 8;
+  required MyEnum1    MyEnum5         = 25 [default = ENTRY_Second];
+  required InnerEnum  my_enum6        = 26;
+
+  repeated string     string_Values1  = 9;
+  repeated string     stringValues2   = 10;
+  optional string     OPTIONAL_String = 11;
+  required string     requiredString  = 12;
+
+  repeated fixed32    repeatedFixed32 = 13;
+
+  required bytes      requiredBytes1  = 14;
+  required bytes      requiredBytes2  = 15;
+  repeated bytes      repeatedBytes1  = 16;
+  repeated bytes      repeatedBytes2  = 17;
+
+  optional SubMessage subMessage1     = 18;
+  repeated SubMessage SUB_MESSAGE2    = 19;
+  required SubMessage sub_message3    = 20;
+
+  oneof oneOfName {
+    SubMessage testMessage1 = 21;
+    SubMessage testMessage2 = 22;
+  }
+
+  oneof oneOfName2 {
+    SubMessage testMessage4 = 23;
+    SubMessage testMessage5 = 24;
+  }
+
+  enum InnerEnum {
+    Inside = 0;
+  }
+
+  extensions 200 to 255;
+}
+
+message TestExtension {
+  extend MainMessage {
+      optional TestExtension testExtension = 250;
+  }
+  optional string stringValue = 1;
+}

--- a/tests/namingstyle_custom/test_custom_naming_style_c.c
+++ b/tests/namingstyle_custom/test_custom_naming_style_c.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "unittests.h"
+#include "custom_naming_style.pb.h"
+
+int main()
+{
+    int status = 0;
+    MainMessage defaultMessage = MAIN_MESSAGE_INIT_DEFAULT;
+    MainMessage message = MAIN_MESSAGE_INIT_ZERO;
+
+    /* Verify the default value was initialized */
+    TEST(defaultMessage.myEnum5 == MY_ENUM1_ENTRY_SECOND);
+
+    /* Verify that all members have the expected names */
+    message.luckyNumber = 13;
+    message.requiredNumber = 1;
+    message.repeatedNumber[0] = 1;
+    message.repeatedInts = NULL;
+
+    message.myEnum1 = MY_ENUM1_ENUM_THIRD;
+    message.myEnum2 = MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum3 = MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum4.arg = NULL;
+
+    message.stringValues1 = NULL;
+    message.stringValues2[0][0] = 'a';
+    message.optionalString.arg = NULL;
+    message.requiredString[0] = 'a';
+
+    message.repeatedFixed32[0] = 1;
+
+    message.requiredBytes1[0] = 0;
+    message.requiredBytes2.size = 0;
+    message.repeatedBytes1_count = 0;
+    message.repeatedBytes2 = NULL;
+
+    message.has_subMessage1 = true;
+    message.subMessage1.has_testValue = true;
+    message.subMessage1.testValue = 0;
+    message.subMessage2.arg = NULL;
+    message.subMessage3.testValue = 0;
+
+    message.which_oneOfName = MAIN_MESSAGE_TEST_MESSAGE2_TAG;
+    message.oneOfName.testMessage2.has_testValue = true;
+    message.oneOfName.testMessage2.testValue = 5;
+
+    message.which_oneOfName2 = MAIN_MESSAGE_TEST_MESSAGE5_TAG;
+    message.testMessage5.testValue = 5;
+
+    TEST(strcmp("ENTRY_FIRST", MyEnum1Name(MY_ENUM1_ENTRY_FIRST)) == 0);
+    TEST(MyEnum1Valid(MY_ENUM1_ENTRY_FIRST) == true);
+    TEST(MyEnum2Valid(MY_ENUM2_ENUM2_ENTRY) == true);
+
+    /* Verify that the descriptor structure is at least mostly correct
+     * by doing a round-trip encoding test.
+     */
+    {
+        uint8_t buffer1[256];
+        uint8_t buffer2[256];
+        pb_ostream_t ostream1 = pb_ostream_from_buffer(buffer1, sizeof(buffer1));
+        pb_ostream_t ostream2 = pb_ostream_from_buffer(buffer2, sizeof(buffer2));
+        pb_istream_t istream;
+        MainMessage message2 = MAIN_MESSAGE_INIT_ZERO;
+
+        TEST(pb_encode(&ostream1, &MainMessage_msg, &message));
+
+        istream = pb_istream_from_buffer(buffer1, ostream1.bytes_written);
+        TEST(pb_decode(&istream, &MainMessage_msg, &message2));
+
+        /* Encoding a second time should produce same output */
+        TEST(pb_encode(&ostream2, &MainMessage_msg, &message2));
+
+        TEST(ostream2.bytes_written == ostream1.bytes_written);
+        TEST(memcmp(buffer1, buffer2, ostream1.bytes_written) == 0);
+    }
+
+    return status;
+}

--- a/tests/namingstyle_custom/test_custom_naming_style_mangle_c.c
+++ b/tests/namingstyle_custom/test_custom_naming_style_mangle_c.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "unittests.h"
+#include "custom_naming_style_mangle.pb.h"
+
+int main()
+{
+    int status = 0;
+    MainMessage defaultMessage = MAIN_MESSAGE_INIT_DEFAULT;
+    MainMessage message = MAIN_MESSAGE_INIT_ZERO;
+    MainMessageInnerEnum inner = _MAIN_MESSAGE_INNER_ENUM_MIN;
+
+    /* Satisfy the usage error, the test was just that the inner enum mapping works. */
+    TEST(inner == MAIN_MESSAGE_INNER_ENUM_INSIDE)
+
+    /* Verify the default value was initialized */
+    TEST(defaultMessage.myEnum5 == MY_ENUM1_ENTRY_SECOND);
+
+    /* Verify that all members have the expected names */
+    message.luckyNumber = 13;
+    message.requiredNumber = 1;
+    message.repeatedNumber[0] = 1;
+    message.repeatedInts = NULL;
+
+    message.myEnum1 = MY_ENUM1_ENUM_THIRD;
+    message.myEnum2 = MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum3 = MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum4.arg = NULL;
+
+    message.stringValues1 = NULL;
+    message.stringValues2[0][0] = 'a';
+    message.optionalString.arg = NULL;
+    message.requiredString[0] = 'a';
+
+    message.repeatedFixed32[0] = 1;
+
+    message.requiredBytes1[0] = 0;
+    message.requiredBytes2.size = 0;
+    message.repeatedBytes1_count = 0;
+    message.repeatedBytes2 = NULL;
+
+    message.has_subMessage1 = true;
+    message.subMessage1.has_testValue = true;
+    message.subMessage1.testValue = 0;
+    message.subMessage2.arg = NULL;
+    message.subMessage3.testValue = 0;
+
+    message.which_oneOfName = MAIN_MESSAGE_TEST_MESSAGE2_TAG;
+    message.oneOfName.testMessage2.has_testValue = true;
+    message.oneOfName.testMessage2.testValue = 5;
+
+    message.which_oneOfName2 = MAIN_MESSAGE_TEST_MESSAGE5_TAG;
+    message.testMessage5.testValue = 5;
+
+    TEST(strcmp("ENTRY_FIRST", MyEnum1Name(MY_ENUM1_ENTRY_FIRST)) == 0);
+    TEST(MyEnum1Valid(MY_ENUM1_ENTRY_FIRST) == true);
+    TEST(MyEnum2Valid(MY_ENUM2_ENUM2_ENTRY) == true);
+
+    /* Verify that the descriptor structure is at least mostly correct
+     * by doing a round-trip encoding test.
+     */
+    {
+        uint8_t buffer1[256];
+        uint8_t buffer2[256];
+        pb_ostream_t ostream1 = pb_ostream_from_buffer(buffer1, sizeof(buffer1));
+        pb_ostream_t ostream2 = pb_ostream_from_buffer(buffer2, sizeof(buffer2));
+        pb_istream_t istream;
+        MainMessage message2 = MAIN_MESSAGE_INIT_ZERO;
+
+        TEST(pb_encode(&ostream1, &MainMessage_msg, &message));
+
+        istream = pb_istream_from_buffer(buffer1, ostream1.bytes_written);
+        TEST(pb_decode(&istream, &MainMessage_msg, &message2));
+
+        /* Encoding a second time should produce same output */
+        TEST(pb_encode(&ostream2, &MainMessage_msg, &message2));
+
+        TEST(ostream2.bytes_written == ostream1.bytes_written);
+        TEST(memcmp(buffer1, buffer2, ostream1.bytes_written) == 0);
+    }
+
+
+    return status;
+}

--- a/tests/namingstyle_custom/test_custom_naming_style_package_c.c
+++ b/tests/namingstyle_custom/test_custom_naming_style_package_c.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "unittests.h"
+#include "custom_naming_style_package.pb.h"
+
+int main()
+{
+    int status = 0;
+    PackageMainMessage defaultMessage = PACKAGE_MAIN_MESSAGE_INIT_DEFAULT;
+    PackageMainMessage message = PACKAGE_MAIN_MESSAGE_INIT_ZERO;
+
+    /* Verify the default value was initialized */
+    TEST(defaultMessage.myEnum5 == PACKAGE_MY_ENUM1_ENTRY_SECOND);
+
+    /* Verify that all members have the expected names */
+    message.luckyNumber = 13;
+    message.requiredNumber = 1;
+    message.repeatedNumber[0] = 1;
+    message.repeatedInts = NULL;
+
+    message.myEnum1 = PACKAGE_MY_ENUM1_ENUM_THIRD;
+    message.myEnum2 = PACKAGE_MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum3 = PACKAGE_MY_ENUM2_ENUM2_ENTRY;
+    message.myEnum4.arg = NULL;
+
+    message.stringValues1 = NULL;
+    message.stringValues2[0][0] = 'a';
+    message.optionalString.arg = NULL;
+    message.requiredString[0] = 'a';
+
+    message.repeatedFixed32[0] = 1;
+
+    message.requiredBytes1[0] = 0;
+    message.requiredBytes2.size = 0;
+    message.repeatedBytes1_count = 0;
+    message.repeatedBytes2 = NULL;
+
+    message.has_subMessage1 = true;
+    message.subMessage1.has_testValue = true;
+    message.subMessage1.testValue = 0;
+    message.subMessage2.arg = NULL;
+    message.subMessage3.testValue = 0;
+
+    message.which_oneOfName = PACKAGE_MAIN_MESSAGE_TEST_MESSAGE2_TAG;
+    message.oneOfName.testMessage2.has_testValue = true;
+    message.oneOfName.testMessage2.testValue = 5;
+
+    message.which_oneOfName2 = PACKAGE_MAIN_MESSAGE_TEST_MESSAGE5_TAG;
+    message.testMessage5.testValue = 5;
+
+    TEST(strcmp("ENTRY_FIRST", PackageMyEnum1Name(PACKAGE_MY_ENUM1_ENTRY_FIRST)) == 0);
+    TEST(PackageMyEnum1Valid(PACKAGE_MY_ENUM1_ENTRY_FIRST) == true);
+    TEST(PackageMyEnum2Valid(PACKAGE_MY_ENUM2_ENUM2_ENTRY) == true);
+
+    /* Verify that the descriptor structure is at least mostly correct
+     * by doing a round-trip encoding test.
+     */
+    {
+        uint8_t buffer1[256];
+        uint8_t buffer2[256];
+        pb_ostream_t ostream1 = pb_ostream_from_buffer(buffer1, sizeof(buffer1));
+        pb_ostream_t ostream2 = pb_ostream_from_buffer(buffer2, sizeof(buffer2));
+        pb_istream_t istream;
+        PackageMainMessage message2 = PACKAGE_MAIN_MESSAGE_INIT_ZERO;
+
+        TEST(pb_encode(&ostream1, &PackageMainMessage_msg, &message));
+
+        istream = pb_istream_from_buffer(buffer1, ostream1.bytes_written);
+        TEST(pb_decode(&istream, &PackageMainMessage_msg, &message2));
+
+        /* Encoding a second time should produce same output */
+        TEST(pb_encode(&ostream2, &PackageMainMessage_msg, &message2));
+
+        TEST(ostream2.bytes_written == ostream1.bytes_written);
+        TEST(memcmp(buffer1, buffer2, ostream1.bytes_written) == 0);
+    }
+
+    return status;
+}


### PR DESCRIPTION
This is an attempt to support custom naming by loading a python module via a module path and class name. I'm happy to hear feedback and suggestions for alternate approaches. I added a test named _namingstyle_custom_, which was copied and modified from _namingstyle_ to use fewer delimiters and more camel and pascal casing.

## Passing in the styler (fourth commit)

I tried to make this more flexible by also passing a class name but it could be simplified by requiring a specific class name if that's preferred. I first tried to pass the arguments in as a tuple (`nargs=2` in `optparser.add_option`) but that didn't seem to play nice when trying to run the tests or running it as a plugin; it kept getting split. I could wrap it in single quotes but then I'd have to strip those which felt wrong, so I switched to passing a single delimited string. A comma seemed appropriate as the delimiter but that didn't play nice in all cases either, so I switched to a dot since passing the option in the form _MODULE.CLASS_ felt better.

The new _--custom-style_ option is manually checked for being mutually exclusive with the _-C/--c-style_ option. I see that _arpparse_ supports this but _optparse_ doesn't seem to. I could create a separate PR to migrate to using _argparse_ if there is any interest.

The value is split via a callback so the parsing/validation can stay within _optparser_. It's then interpreted as being a file path, optionally with a `".py"` extension. The module name is simply the basename without the extension.

The module is loaded using the approach from [an example in the python docs](https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly) and put into a local class so that _NamingStyle_ is used as the last inherited class (or _NamingStyleC_ if the _-C/--c-style_ flag is also used), allowing the custom styler to only implement the methods they want to modify.

## Modification to support more styling (all commits)

When using a custom styler I noticed a few places where I had issues with styling. Note that all tests still pass after these changes and I only saw one difference in the generated code (see below).

The reverse name mapping was affected when there was a package name that was stripped via mangling. It would generate mappings to things that were part way between being properly styled and canonical. To remedy this, I checked if the styled name was different and if the canonical name was different (to match a check that was being used when yielding the mapping definitions. I think this only affects custom stylings but it ends up with a mapping to a mapping. Here's an example from _custom_naming_style_mangle.pb.h_ that is generated from the new test:

```c
/* Mapping from canonical names (mangle_names or overridden package name) */
#define package_MY_ENUM2 MY_ENUM2
#define MY_ENUM2 MyEnum2
```

If I didn't to the double mapping, generation would fail elsewhere because it would fail to lookup enums from the dependencies.

43140b349631db814588aa8d12252cdc444aaed6 now simply uses the last part of the long names for each enum instead of trying to strip the type name prefix from it, which was assuming there was a single `_` as the delimiter. This avoids that assumption.

af7ec95dd18021b8dee09e41ba4e28716c53845a removes a double-styling that was occurring for static bytes types. It was getting styled by calling `var_name`, which didn't feel quite right to me since it was a `typedef`, but the underlying `ctype` already gets styled by calling `bytes_type(...)` in the `Field.__init__` method: https://github.com/nanopb/nanopb/blob/af7ec95dd18021b8dee09e41ba4e28716c53845a/generator/nanopb_generator.py#L746
This happened to work out because the styling was effectively the same, but would be a problem for a custom styler.

daa170bd9694bcf703afccb998bb3aa8b45d4717 styles the extension fields as variables. This only affects the generated output when using the _-C/--c-style_ flag. You can see a diff below of _naming_style.pb.c_ that gets generated from the _namingstyle_ test:

```diff
 #define TEST_EXTENSION_TEST_EXTENSION_EXTMSG_CALLBACK NULL
 #define TEST_EXTENSION_TEST_EXTENSION_EXTMSG_DEFAULT NULL
 #define test_extension_test_extension_extmsg_t_test_extension_MSGTYPE test_extension_t
-pb_byte_t TestExtension_testExtension_extmsg_default[] = {0x00};
+pb_byte_t test_extension_test_extension_extmsg_default[] = {0x00};
 PB_BIND(TEST_EXTENSION_TEST_EXTENSION_EXTMSG, test_extension_test_extension_extmsg_t, 2)
 const pb_extension_type_t test_extension_test_extension = {
     NULL,
```