### PR TITLE
Fix custom naming styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ generator/nanopb_pb2.pyc
 bazel-*
 extra/poetry/build
 build/
+.idea

--- a/tests/namingstyle_custom/SConscript
+++ b/tests/namingstyle_custom/SConscript
@@ -14,10 +14,17 @@ Depends(proto, style)
 proto = env.NanopbProto(["custom_naming_style_mangle", "custom_naming_style_mangle.options"])
 Depends(proto, style)
 
+proto = env.NanopbProto(["custom_naming_style_other", "custom_naming_style_other.options"])
+Depends(proto, style)
+proto = env.NanopbProto(["custom_naming_style_importer", "custom_naming_style_importer.options", "custom_naming_style_other", "custom_naming_style_other.options"])
+Depends(proto, style)
+
 test = env.Program(["test_custom_naming_style_c.c", "custom_naming_style.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
 mangle = env.Program(["test_custom_naming_style_mangle_c.c", "custom_naming_style_mangle.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
 package = env.Program(["test_custom_naming_style_package_c.c", "custom_naming_style_package.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+importer = env.Program(["test_custom_naming_style_importer_c.c", "custom_naming_style_importer.pb.c", "custom_naming_style_other.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
 
 env.RunTest(test)
 env.RunTest(mangle)
 env.RunTest(package)
+env.RunTest(importer)

--- a/tests/namingstyle_custom/custom_naming_style_importer.options
+++ b/tests/namingstyle_custom/custom_naming_style_importer.options
@@ -1,0 +1,1 @@
+* mangle_names:M_STRIP_PACKAGE

--- a/tests/namingstyle_custom/custom_naming_style_importer.proto
+++ b/tests/namingstyle_custom/custom_naming_style_importer.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+import "custom_naming_style_other.proto";
+
+package importer;
+
+enum MyEnum {
+  MY_ENUM_NONE = 0;
+  MY_ENUM_SOMETHING = 1;
+}
+
+message MainMessage {
+  required MyEnum my_own_enum = 1;
+  required other.THE_OTHER_ENUM imported_enum = 2;
+  required other.AnotherEnum another_imported_enum = 3;
+}

--- a/tests/namingstyle_custom/custom_naming_style_other.options
+++ b/tests/namingstyle_custom/custom_naming_style_other.options
@@ -1,0 +1,1 @@
+* mangle_names:M_STRIP_PACKAGE

--- a/tests/namingstyle_custom/custom_naming_style_other.proto
+++ b/tests/namingstyle_custom/custom_naming_style_other.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package other;
+
+enum THE_OTHER_ENUM {
+  OTHER_UNSET = 0;
+  OTHER_SET = 1;
+}
+
+enum AnotherEnum {
+  ANOTHER_UNSET = 0;
+}

--- a/tests/namingstyle_custom/test_custom_naming_style_importer_c.c
+++ b/tests/namingstyle_custom/test_custom_naming_style_importer_c.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "unittests.h"
+#include "custom_naming_style_other.pb.h"
+#include "custom_naming_style_importer.pb.h"
+
+int main()
+{
+    int status = 0;
+    MainMessage defaultMessage = MAIN_MESSAGE_INIT_DEFAULT;
+
+    TEST(defaultMessage.myOwnEnum == MY_ENUM_MY_ENUM_NONE);
+    TEST(defaultMessage.importedEnum == THE_OTHER_ENUM_OTHER_UNSET);
+    TEST(defaultMessage.anotherImportedEnum == ANOTHER_ENUM_ANOTHER_UNSET);
+
+    return status;
+}


### PR DESCRIPTION
This fixes #1027 which has an example of the problem. I added a test that breaks and demonstrates the issue, and then fixed it in the following commit.

Here is a snippet from the imported _custom_naming_style_other.pb.h_:

```c
/* Enum definitions */
typedef enum _TheOtherEnum {
    THE_OTHER_ENUM_OTHER_UNSET = 0,
    THE_OTHER_ENUM_OTHER_SET = 1
} TheOtherEnum;

typedef enum _AnotherEnum {
    ANOTHER_ENUM_ANOTHER_UNSET = 0
} AnotherEnum;

/* Mapping from canonical names (mangle_names or overridden package name) */
#define other_THE_OTHER_ENUM THE_OTHER_ENUM
#define THE_OTHER_ENUM OtherTheOtherEnum
#define OtherTheOtherEnum TheOtherEnum

#define other_AnotherEnum AnotherEnum
#define OtherAnotherEnum other_AnotherEnum
```

It now also provides a definition for the styled/unmangled type names. The tricky part about it was trying to ensure the mapping existed while not accidentally re-defining the type name, ensuring there isn't a circular definition, and not breaking how enum dependencies are looked up and unmangled via the `reverse_name_mapping` dictionary. I added some extra comments around that to try to make it more clear.

This didn't change the generated files for any of the existing tests outside of the _namingstyle_custom_ directory.