### PR TITLE
Add pip requirements file for zephyr module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -2,3 +2,7 @@ name: nanopb
 build:
   cmake-ext: True
   kconfig-ext: True
+package-managers:
+  pip:
+    requirement-files:
+      - extra/requirements.txt


### PR DESCRIPTION
Update the `zephyr/module.yml` with pip requirements.

Zephyr has introduced an extension which allows external modules to describe Python dependencies for `pip`.
See https://github.com/zephyrproject-rtos/zephyr/pull/80782