### PR TITLE
bazel: Tidy up protoc-gen-nanopb

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,12 +1,11 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@nanopb_pypi//:requirements.bzl", "requirement")
-load("@rules_python//python:proto.bzl", "py_proto_library")
 
 # Note: if you are still using WORKSPACE, you will need to patch this file to use the following instead
 # load("@python_3_11//:defs.bzl", "py_binary")
 load("@python_versions//3.11:defs.bzl", "py_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_proto_grpc//:defs.bzl", "proto_plugin")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
 load("//extra/bazel:nanopb_cc_proto_library.bzl", "cc_nanopb_proto_library")
 
@@ -49,12 +48,14 @@ py_binary(
     data = glob([
         "generator/**/*.proto",
     ]),
+    env = {
+        "NANOPB_PB2_NO_REBUILD": "1",
+    },
     imports = [
         "generator",
     ],
     deps = [
         ":nanopb_py_proto",
-        requirement("grpcio-tools"),
     ],
 )
 


### PR DESCRIPTION
As I dug more into the issue discussed in
https://github.com/nanopb/nanopb/pull/1034 (a collision between the protoc versions in `MODULE.bazel` and `grpcio-tools`), I realized that it surfaced only because of the dependency on `grpcio-tools` in the plugin binary.  But this dependency is unnecessary. The purpose of the `grpcio-tools` dependency in general is to allow nanopb to invoke protoc. But we don't need to do this from this target:

1. We never need to rebuild nanopb_pb2.py ourselves, because we have a dep on `:nanopb_py_proto`. (So, we can set `NANOPB_PB2_NO_REBUILD=1`.)
2. The protoc-gen-nanopb binary is meant to be invoked as a protoc plugin, so it doesn't need to invoke protoc itself at runtime.

This PR fixes the same issue, and in a more durable way. If version skew between the pip and `MODULE.bazel` versions of protobuf is reintroduced in the future, this will not affect protoc-gen-nanopb, because this binary no longer pulls in the pip dependency at all.