### PR TITLE
add version generation for CPE and PURL in zephyr/module.yml

### DIFF
--- a/tools/set_version.sh
+++ b/tools/set_version.sh
@@ -8,6 +8,8 @@ VERSION_NUMBER_ONLY=$(echo $1 | cut -d '-' -f 2)
 sed -i -e 's/nanopb_version\s*=\s*"[^"]*"/nanopb_version = "'$1'"/' generator/nanopb_generator.py
 sed -i -e 's/#define\s*NANOPB_VERSION\s*.*/#define NANOPB_VERSION "'$1'"/' pb.h
 sed -i -e 's/project(\s*nanopb\s*VERSION\s*[^)]*\s*LANGUAGES\s*C\s*)/project(nanopb VERSION '$VERSION_NUMBER_ONLY' LANGUAGES C)/' CMakeLists.txt
+sed -i -e 's/nanopb\@[^\s]*/nanopb\@'$VERSION_NUMBER_ONLY'/' zephyr/module.yml 
+sed -i -e 's/cpe:2.3:a:nanopb_project:nanopb:[^:]*/cpe:2.3:a:nanopb_project:nanopb:'$VERSION_NUMBER_ONLY'/' zephyr/module.yml 
 # Update the first occurrence of "version" in MODULE.bazel, which is the nanopb
 # version. Use awk instead of sed because there is no sed approach that works on
 # both Linux and MacOS (https://stackoverflow.com/q/148451/24291280).

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -6,3 +6,7 @@ package-managers:
   pip:
     requirement-files:
       - extra/requirements.txt
+security:
+  external-references:
+    - cpe:2.3:a:nanopb_project:nanopb:1.0.0:*:*:*:*:*:*:*
+    - pkg:github/nanopb/nanopb@1.0.0


### PR DESCRIPTION
Adds version generation of PURL and CPE for Zephyr (https://github.com/nanopb/nanopb/issues/1041).

Question would be what PURL to use: `pkg:generic/nanopb`  is already used by e.g. OSV  (https://test.osv.dev/vulnerability/OSV-2020-1567) or `pkg:github/nanopb/nanopb` which would be closer to the purl spec https://github.com/package-url/purl-spec?tab=readme-ov-file#some-purl-examples  
Are there any other scanners already nanopb PURLs?