### PR TITLE
Add Ability To Inject Compilation Options in Bazel Build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,15 @@ licenses(["notice"])
 exports_files(["LICENSE.txt"])
 
 cc_library(
+    name = "nanopb_compilation_options_default"
+)
+
+label_flag(
+    name = "nanopb_compilation_options",
+    build_setting_default = ":nanopb_compilation_options_default"
+)
+
+cc_library(
     name = "nanopb",
     srcs = [
         "pb_common.c",
@@ -29,6 +38,7 @@ cc_library(
         "pb_encode.h",
     ],
     visibility = ["//visibility:public"],
+    deps = [":nanopb_compilation_options"],
 )
 
 copy_file(


### PR DESCRIPTION
When building nanopb with Bazel, the developer may want to define their own compilation options (https://jpa.kapsi.fi/nanopb/docs/reference.html#compilation-options). Today, that is do able with a global `-Ddefine` specified via the command line. But that doesn't support use cases such as `PB_SYSTEM_HEADER` where additional header files need to be support.

It also forces the `defines` for nanopb to be applied to all compiled files such that, if you can one of the defines, all compiled files need to be recompiled.

With this change, a developer can apply `defines` for anything that uses nanopb only, by using a transitions, or a command line option to set the library to use for nanopb.