### PR TITLE
Compute size of all statically known messages

### DIFF
--- a/tests/message_sizes/dummy.c
+++ b/tests/message_sizes/dummy.c
@@ -5,13 +5,7 @@
 int main()
 {
     PB_STATIC_ASSERT(MESSAGES2_PB_H_MAX_SIZE == xmit_size, INCORRECT_MAX_SIZE);
-    // Computed 13 bytes by waiting for compilation error.
-    // Purpose is to check that if a message has a submessage callback,
-    // the size of the message can still be computed.
     PB_STATIC_ASSERT(13 == WithCallbackSubmsg_size, INCORRECT_MAX_SIZE);
-    // Computed 13 bytes by waiting for compilation error.
-    // Purpose is to check that if a message has a type FT_POINTER,
-    // the size of the message can still be computed.
     PB_STATIC_ASSERT(13 == WithPointerSubmsg_size, INCORRECT_MAX_SIZE);
     return xmit_size;
 }

--- a/tests/message_sizes/dummy.c
+++ b/tests/message_sizes/dummy.c
@@ -5,6 +5,13 @@
 int main()
 {
     PB_STATIC_ASSERT(MESSAGES2_PB_H_MAX_SIZE == xmit_size, INCORRECT_MAX_SIZE);
+    // Computed 13 bytes by waiting for compilation error.
+    // Purpose is to check that if a message has a submessage callback,
+    // the size of the message can still be computed.
+    PB_STATIC_ASSERT(13 == WithCallbackSubmsg_size, INCORRECT_MAX_SIZE);
+    // Computed 13 bytes by waiting for compilation error.
+    // Purpose is to check that if a message has a type FT_POINTER,
+    // the size of the message can still be computed.
+    PB_STATIC_ASSERT(13 == WithPointerSubmsg_size, INCORRECT_MAX_SIZE);
     return xmit_size;
 }
-

--- a/tests/message_sizes/messages2.proto
+++ b/tests/message_sizes/messages2.proto
@@ -8,3 +8,18 @@ message xmit {
    required bytes data = 2 [(nanopb).max_size = 128];
 }
 
+message CallbackSub {
+    required int32 value = 1;
+}
+
+message WithCallbackSubmsg {
+    required CallbackSub submsg = 1 [(nanopb).submsg_callback = true];
+}
+
+message PointerSub {
+    required int32 value = 1;
+}
+
+message WithPointerSubmsg {
+    required PointerSub submsg = 1 [(nanopb).type = FT_POINTER];
+}

--- a/tests/options/options_h.expected
+++ b/tests/options/options_h.expected
@@ -13,7 +13,7 @@ Message5_EnumValue1
 #define PB_MSG_105 Message5
 #define OPTIONS_MESSAGES \\
 \s+PB_MSG\(103,[0-9]*,Message3\) \\
-\s+PB_MSG\(104,-1,Message4\) \\
+\s+PB_MSG\(104,[0-9]*,Message4\) \\
 \s+PB_MSG\(105,[0-9]*,Message5\) \\
 #define Message5_msgid 105
 ! has_proto3field


### PR DESCRIPTION
Fields that have a user defined different type (such as a FT_POINTER) may still have a known encoded size.

This pull requests computes the encoded sizes of those messages to ensure that, if nanopb has enough information to know the encoded size, it is reported.