### PR TITLE
Adds a selectable `--extension` to Bazel builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        extension: [.pb, .nanopb]
         os: [ubuntu-latest, macos-latest]
 
     steps:
@@ -28,8 +29,8 @@ jobs:
 
       - name: Test
         run: |
-          bazelisk test //...
+          bazelisk test --//:nanopb_extension=${{ matrix.extension }} //...
 
       - name: Build
         run: |
-          bazelisk build //...
+          bazelisk build --//:nanopb_extension=${{ matrix.extension }} //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 # Note: if you are still using WORKSPACE, you will need to patch this file to use the following instead
 # load("@python_3_11//:defs.bzl", "py_binary")
@@ -69,6 +70,26 @@ py_binary(
     ],
 )
 
+string_flag(
+    name = "nanopb_extension",
+    values = [".pb", ".nanopb"],
+    build_setting_default = ".pb",
+)
+
+config_setting(
+    name = "nanopb_extension_default",
+    flag_values = {
+        ":nanopb_extension": ".pb"
+    }
+)
+
+config_setting(
+    name = "nanopb_extension_nanopb",
+    flag_values = {
+        ":nanopb_extension": ".nanopb"
+    }
+)
+
 proto_plugin(
     name = "nanopb_plugin",
     env = {
@@ -77,10 +98,16 @@ proto_plugin(
     options = [
         "--library-include-format=quote",
     ],
-    outputs = [
-        "{protopath}.pb.h",
-        "{protopath}.pb.c",
-    ],
+    outputs = select({
+        ":nanopb_extension_default": [
+            "{protopath}.pb.h",
+            "{protopath}.pb.c",
+        ],
+        ":nanopb_extension_nanopb": [
+            "{protopath}.nanopb.h",
+            "{protopath}.nanopb.c",
+        ],
+    }),
     separate_options_flag = True,
     tool = ":protoc-gen-nanopb",
     use_built_in_shell_environment = False,
@@ -124,6 +151,10 @@ cc_test(
     name = "bazel_options_support",
     srcs = ["tests/bazel_options_support/bazel_options_support.cc"],
     deps = [":all_types_nanopb"],
+    copts = select({
+        ":nanopb_extension_nanopb": ["-DUSE_NANOPB_EXTENSION_NAME"],
+        ":nanopb_extension_default": [],
+    }),
 )
 
 # Run `bazel run //:requirements.update` if you want to update the requirements.

--- a/docs/bazel_build.md
+++ b/docs/bazel_build.md
@@ -55,3 +55,32 @@ cc_nanopb_proto_library(
     visibility = ["//visibility:private"],
 )
 ```
+
+## Bazel Configuration Options
+
+### Use a non-default extension
+
+By default, nanopb generates files with extension `.pb`, which ends up creating
+names such as `my_proto.pb.h` and `my_proto.pb.c`. This naming pattern conflicts
+with `cc_proto_library` rules, which generate files with the same names.
+
+To resolve this conflict, we provide a `string_flag` `//:nanopb_extension` that
+currently accepts two options: `.pb` and `.nanopb`. (In the future, we could
+pontentially accept your choice of input, but that was tricky to do, so to start
+with only these two options are supported.)
+
+To build `nanopb` files with the `.nanopb` extension (creating files of
+`my_proto.nanopb.h` and `my_proto.nanopb.c`) you can add the following to your
+command line:
+
+```
+bazel build --@nanopb//:nanopb_extension=".nanopb"
+```
+
+If you want to apply this to all nanopb files, add the above to your `.bazelrc`
+file:
+
+```
+# .bazelrc
+build --@nanopb//:nanopb_extension=".nanopb"
+```

--- a/extra/bazel/nanopb_cc_proto_library.bzl
+++ b/extra/bazel/nanopb_cc_proto_library.bzl
@@ -9,6 +9,7 @@ load(
     "proto_compile_attrs",
     "proto_compile",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def cc_nanopb_proto_compile_impl(ctx):
     """Nanopb proto compile implementation to add options files."""
@@ -19,6 +20,9 @@ def cc_nanopb_proto_compile_impl(ctx):
             extra_protoc_args = extra_protoc_args + [
                 "--nanopb_plugin_opt=-f{}".format(options_file.path)]
             extra_protoc_files = extra_protoc_files + [options_file]
+    extra_protoc_args = extra_protoc_args + [
+        "--nanopb_plugin_opt=--extension={}".format(ctx.attr._extension[BuildSettingInfo].value)
+    ]
     return proto_compile(ctx, ctx.attr.options, extra_protoc_args, extra_protoc_files)
 
 
@@ -26,6 +30,10 @@ nanopb_proto_compile_attrs = dict(
     nanopb_options_files = attr.label_list(
         allow_files = [".options"],
         doc = "An optional list of additional nanopb options files to apply",
+    ),
+    _extension = attr.label(
+        doc = "Private field to allow //:nanopb_extension string_flag to apply",
+        default = "//:nanopb_extension",
     ),
     **proto_compile_attrs,
 )

--- a/tests/bazel_options_support/bazel_options_support.cc
+++ b/tests/bazel_options_support/bazel_options_support.cc
@@ -1,4 +1,8 @@
+#ifdef USE_NANOPB_EXTENSION_NAME
+#include "tests/alltypes/alltypes.nanopb.h"
+#else
 #include "tests/alltypes/alltypes.pb.h"
+#endif
 
 int main(int argc, char* argv[]) {
 	IntSizes intSizes;


### PR DESCRIPTION
By default, nanopb generates files such as `my_proto.pb.h` and `my_proto.pb.c`. Unfortunately, `cc_proto_library` also generates files with the name `my_proto.pb.h`, which can lead to confusing errors as `gcc` looks for the right include path for `nanopb` files.

This PR adds a feature to bazel builds to allow an user to choose an alternate extension (`.nanopb`) so avoid this conflict.