### PR TITLE
add support for custom `noinline` definition

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -132,7 +132,11 @@ extern "C" {
 /* Define for explicitly not inlining a given function */
 #if defined(__GNUC__) || defined(__clang__)
     /* For GCC and clang */
+#   if defined(noinline)
+#   define pb_noinline noinline
+#   else
 #   define pb_noinline __attribute__((noinline))
+#   endif
 #elif defined(__ICCARM__) || defined(__CC_ARM)
     /* For IAR ARM and Keil MDK-ARM compilers */
 #   define pb_noinline


### PR DESCRIPTION
I have a gcc compiled environment, where `inline` is defined as a macro already when compile hits nanopb, and thus compilation fails. The aforementioned macro definition is like the one here: https://elixir.bootlin.com/linux/v6.15.7/source/include/linux/compiler_attributes.h#L231

This PR checks if `noinline` is "redefined" as a macro and skips creating a new definition for it.