### PR TITLE
Fix(PlatformIO): Add library include path for generated sources #1117

### DIFF
--- a/generator/platformio_generator.py
+++ b/generator/platformio_generator.py
@@ -151,14 +151,18 @@ else:
             if options_file:
                 pathlib.Path(options_file_md5_abs).write_text(options_file_current_md5)
 
-    #
-    # Add generated includes and sources to build environment
-    #
+    # 1. Add path to the generated headers, so main.cpp can find them.
     env.Append(CPPPATH=[generated_src_dir])
 
+    # 2. Add path to the Nanopb library itself, so the generated
+    #    .c file can find the core headers like pb.h https://github.com/nanopb/nanopb/issues/1117
+    env.Append(CPPPATH=[nanopb_root])
+
+    # 3. Compile the generated sources
     # Fix for ESP32 ESP-IDF https://github.com/nanopb/nanopb/issues/734#issuecomment-1001544447
     global_env = DefaultEnvironment()
     already_called_env_name = "_PROTOBUF_GENERATOR_ALREADY_CALLED_" + env['PIOENV'].replace("-", "_")
     if not global_env.get(already_called_env_name, False):
         env.BuildSources(generated_build_dir, generated_src_dir)
     global_env[already_called_env_name] = True
+


### PR DESCRIPTION
### Description

This PR fixes an issue where the compilation of auto-generated `.pb.c` files fails on the `espressif32` platform within the Arduino framework. The compiler was unable to find the core Nanopb header `pb.h`.

The issue was specific to the `espressif32` platform; the same configuration compiles successfully on `espressif8266`.

---

### Cause of the Issue

The `platformio_generator.py` script correctly adds the generated source files to the build process using `env.BuildSources`. However, it failed to append the path to the Nanopb core library itself to the `CPPPATH` for this specific build job. As a result, the compiler did not know where to find `<pb.h>` when compiling the generated C file.

---

### The Fix ⚙️

This PR resolves the issue by adding the library's root directory (`nanopb_root`) to the `CPPPATH` just before `env.BuildSources` is called. This provides the necessary include path to the compiler, allowing it to find the core headers.

The change is minimal and ensures that the build process is now robust for the `espressif32` platform, mirroring the successful behavior on other platforms.