### PR TITLE
Use styled naming when generating c++ lookup code

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1555,15 +1555,15 @@ class Message(ProtoElement):
 
     def fields_declaration_cpp_lookup(self, local_defines):
         result = 'template <>\n'
-        result += 'struct MessageDescriptor<%s> {\n' % (self.name)
+        result += 'struct MessageDescriptor<%s> {\n' % (Globals.naming_style.type_name(self.name))
         result += '    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = %d;\n' % (self.count_all_fields())
 
-        size_define = "%s_size" % (self.name)
+        size_define = "%s_size" % (Globals.naming_style.type_name(self.name))
         if size_define in local_defines:
             result += '    static PB_INLINE_CONSTEXPR const pb_size_t size = %s;\n' % (size_define)
 
         result += '    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {\n'
-        result += '        return &%s_msg;\n' % (self.name)
+        result += '        return &%s_msg;\n' % (Globals.naming_style.type_name(self.name))
         result += '    }\n'
         result += '    static PB_INLINE_CONSTEXPR bool has_msgid() {\n'
         result += '        return %s;\n' % ("true" if hasattr(self, "msgid") else "false", )


### PR DESCRIPTION
When i was using the C++ lookup generation, I saw that the naming style is hardcoded to be only the "default" style. 
While when a user applies the c-naming style and the C++ lookup by using the command line arguments: `--cpp-descriptors -C`, the naming is not correct in the generated C++ code, giving a compiler error. 

I'm not sure if I overlooked something, this is my first PR. 