### PR TITLE
C++ descriptor size needs to be guarded

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -1560,7 +1560,10 @@ class Message(ProtoElement):
 
         size_define = "%s_size" % (Globals.naming_style.type_name(self.name))
         if size_define in local_defines:
+            result += '/* The size define we are using may be defined conditionally guarded. */\n'
+            result += '#if defined %s\n' % size_define
             result += '    static PB_INLINE_CONSTEXPR const pb_size_t size = %s;\n' % (size_define)
+            result += '#endif\n'
 
         result += '    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {\n'
         result += '        return &%s_msg;\n' % (Globals.naming_style.type_name(self.name))


### PR DESCRIPTION
The define that is being used to define the C++ descriptor size may itself
be undefined due to various guards.  Make sure it is available before
defining the C++ size.
