### PR TITLE
Use cc_library from rules_cc//cc:defs.bzl; buildifier lint .

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
@@ -17,12 +18,12 @@ licenses(["notice"])
 exports_files(["LICENSE.txt"])
 
 cc_library(
-    name = "nanopb_compilation_options_default"
+    name = "nanopb_compilation_options_default",
 )
 
 label_flag(
     name = "nanopb_compilation_options",
-    build_setting_default = ":nanopb_compilation_options_default"
+    build_setting_default = ":nanopb_compilation_options_default",
 )
 
 cc_library(
@@ -72,22 +73,25 @@ py_binary(
 
 string_flag(
     name = "nanopb_extension",
-    values = [".pb", ".nanopb"],
     build_setting_default = ".pb",
+    values = [
+        ".pb",
+        ".nanopb",
+    ],
 )
 
 config_setting(
     name = "nanopb_extension_default",
     flag_values = {
-        ":nanopb_extension": ".pb"
-    }
+        ":nanopb_extension": ".pb",
+    },
 )
 
 config_setting(
     name = "nanopb_extension_nanopb",
     flag_values = {
-        ":nanopb_extension": ".nanopb"
-    }
+        ":nanopb_extension": ".nanopb",
+    },
 )
 
 proto_plugin(
@@ -150,11 +154,11 @@ cc_nanopb_proto_library(
 cc_test(
     name = "bazel_options_support",
     srcs = ["tests/bazel_options_support/bazel_options_support.cc"],
-    deps = [":all_types_nanopb"],
     copts = select({
         ":nanopb_extension_nanopb": ["-DUSE_NANOPB_EXTENSION_NAME"],
         ":nanopb_extension_default": [],
     }),
+    deps = [":all_types_nanopb"],
 )
 
 # Run `bazel run //:requirements.update` if you want to update the requirements.

--- a/extra/bazel/nanopb_cc_proto_library.bzl
+++ b/extra/bazel/nanopb_cc_proto_library.bzl
@@ -6,8 +6,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@rules_proto_grpc//:defs.bzl",
     "ProtoPluginInfo",
-    "proto_compile_attrs",
     "proto_compile",
+    "proto_compile_attrs",
 )
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
@@ -18,13 +18,13 @@ def cc_nanopb_proto_compile_impl(ctx):
     for options_target in ctx.attr.nanopb_options_files:
         for options_file in options_target.files.to_list():
             extra_protoc_args = extra_protoc_args + [
-                "--nanopb_plugin_opt=-f{}".format(options_file.path)]
+                "--nanopb_plugin_opt=-f{}".format(options_file.path),
+            ]
             extra_protoc_files = extra_protoc_files + [options_file]
     extra_protoc_args = extra_protoc_args + [
-        "--nanopb_plugin_opt=--extension={}".format(ctx.attr._extension[BuildSettingInfo].value)
+        "--nanopb_plugin_opt=--extension={}".format(ctx.attr._extension[BuildSettingInfo].value),
     ]
     return proto_compile(ctx, ctx.attr.options, extra_protoc_args, extra_protoc_files)
-
 
 nanopb_proto_compile_attrs = dict(
     nanopb_options_files = attr.label_list(
@@ -35,9 +35,8 @@ nanopb_proto_compile_attrs = dict(
         doc = "Private field to allow //:nanopb_extension string_flag to apply",
         default = "//:nanopb_extension",
     ),
-    **proto_compile_attrs,
+    **proto_compile_attrs
 )
-
 
 # Create compile rule
 cc_nanopb_proto_compile = rule(
@@ -54,7 +53,6 @@ cc_nanopb_proto_compile = rule(
     ),
     toolchains = [str(Label("@rules_proto//proto:toolchain_type"))],
 )
-
 
 def cc_nanopb_proto_library(name, **kwargs):  # buildifier: disable=function-docstring
     # Compile protos

--- a/extra/bazel/nanopb_deps.bzl
+++ b/extra/bazel/nanopb_deps.bzl
@@ -13,7 +13,7 @@ def nanopb_deps():
                 "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
             ],
         )
-        
+
     # Setup proto rules.
     # Used by: com_github_nanopb_nanopb, rules_proto_grpc.
     # Used in modules: root.

--- a/extra/bazel/python_deps.bzl
+++ b/extra/bazel/python_deps.bzl
@@ -1,6 +1,6 @@
 load("@rules_python//python:pip.bzl", "pip_parse")
 
-def nanopb_python_deps(interpreter=None):
+def nanopb_python_deps(interpreter = None):
     # Required for python deps for generator plugin.
     # Used by: nanopb.
     # Used in modules: generator.


### PR DESCRIPTION
This change is the result of running `buildifier -r --lint=fix .`. There are some whitespace/formatting changes to build files.

Native C++-related rules (including `cc_library` and `cc_binary`) were removed from the core Bazel binary in the Bazel 9.0.0 release. This marks the conclusion of the Starlarkification effort, requiring language-specific rules to be loaded from their respective modules (e.g., @rules_cc).

Buildifier automatically replaced native usages with explicit load statements from the rules_cc repository.