### PR TITLE
bazel: add grpcio_tools to protoc-gen-nanopb deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -67,6 +67,7 @@ py_binary(
         "generator",
     ],
     deps = [
+        "@nanopb_pypi//grpcio_tools:pkg",
         ":nanopb_py_proto",
     ],
 )


### PR DESCRIPTION
This PR adds `grpcio-tools` to the `protoc-gen-nanopb` dependencies in Bazel.

Without this, the generator falls back to the system's `protoc`, which causes `VersionError` crashes when the system version (e.g., 33.1) doesn't match the project's protobuf runtime (e.g., 28.3). This change ensures the generator uses the version-locked `protoc` from the Python package within the sandbox.