### PR TITLE
fix(platformio): handle subdirectories when preserve_directory_hierarchy=true

### DIFF
--- a/generator/platformio_generator.py
+++ b/generator/platformio_generator.py
@@ -143,8 +143,12 @@ else:
             print(f"[nanopb] Skipping '{proto_file}' ({options_info})")
         else:
             print(f"[nanopb] Processing '{proto_file}' ({options_info})")
-            cmd = [python_exe, nanopb_generator] + nanopb_options + [proto_file_basename]
-            action = SCons.Action.CommandAction(cmd)
+            if nanopb_preserve_hierarchy:
+                nanopb_options.append(proto_file)
+            else:
+                nanopb_options.append(proto_file_basename)
+            cmd = [python_exe, nanopb_generator] + nanopb_options
+            action = SCons.Action.CommandAction(cmd, chdir=project_dir)
             result = env.Execute(action)
             if result != 0:
                 print(f"[nanopb] ERROR: ({result}) processing cmd: '{cmd}'")


### PR DESCRIPTION
This fixes #1145, which I submitted without testing. My apologies for that.

When proto-path is not specified, nanopb resolves path to the .proto file
relative to its working directory. This commit makes nanopb run from the project
root (set by `project_dir` option), and provides full relative path to the
.proto files.

---

#1145 was reverted in 99c830db6238892cea1d7957f7196c20bc5bbce6, probably because of this problem, so I'm including it again.

Again, sorry for the inconvenience!