### PR TITLE
pb_encode: guard buf_write memcpy against NULL buf (fixes #1141)

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -54,9 +54,18 @@ static bool checkreturn buf_write(pb_ostream_t *stream, const pb_byte_t *buf, si
 {
     pb_byte_t *dest = (pb_byte_t*)stream->state;
     stream->state = dest + count;
-    
-    memcpy(dest, buf, count * sizeof(pb_byte_t));
-    
+
+    /* Skip the copy if buf is NULL. Callers should not invoke this with NULL,
+     * but pb_write may pass NULL for sizing passes. Some compilers
+     * (e.g. picolibc/arm-zephyr-eabi GCC 12.2) emit a -Wnonnull warning
+     * against memcpy's nonnull argument even though count would be 0 in
+     * that case. See #1141.
+     */
+    if (buf != NULL)
+    {
+        memcpy(dest, buf, count * sizeof(pb_byte_t));
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Fixes #1141.

### The warning

Some compiler + libc combinations - reported for picolibc + arm-zephyr-eabi GCC 12.2 /
zephyr-sdk-0.17.2 - emit a `-Wnonnull` warning against the `memcpy` in `buf_write`:

```
pb_encode.c:58:5: warning: argument 2 null where non-null expected [-Wnonnull]
   58 |     memcpy(dest, buf, count * sizeof(pb_byte_t));
```

The call is already guarded by pb_write's `if (count > 0 && stream->callback != NULL)`,
so functionally there isn't a bug. But the compiler's nonnull analysis doesn't prove
through the inlining chain (pb_encode_submessage -> pb_write -> buf_write -> memcpy),
so the warning still fires for downstream users - and shows up as an error under
`-Werror` in Zephyr-like CI pipelines.

### The fix

Add an explicit `if (buf != NULL)` guard around the `memcpy` in `buf_write`. This is
the fix the maintainer (@PetteriAimonen) suggested in the issue thread:

>  As a workaround, you can either add `-Wno-nonnull` or perhaps patch in a
>  `buf != NULL` check.

The copy is a no-op when `buf` is NULL (in which case `count` is already zero via
the caller guard), so this is a strict no-op at runtime for any existing correct
caller; it just documents the intent to the compiler's non-null analysis.

### No behavioural regression

- Correct callers (pb_write and anyone that goes through it) never pass a NULL
  `buf` with a non-zero `count`.
- If a caller ever did pass `count == 0` with any `buf`, the prior `memcpy(..., 0)`
was already a no-op at the semantic level (albeit undefined per C standard if buf==NULL).
  The guard now makes that semantic explicit.

### Verification (local)

```
clang -fsyntax-only -Wall -Wnonnull -I. pb_encode.c
# No warnings.
```

Didn't run the full SCons test suite locally (requires protoc + valgrind + external deps);
deferring to CI for the full matrix. As the change is a strict no-op at runtime,
all existing buf_write paths through pb_write remain identical.