### PR TITLE
Update actions and fix ci for forks

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Mount bazel cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: "/home/runner/.cache/bazel"
           key: ${{ runner.os }}-bazel

--- a/.github/workflows/binary_packages.yml
+++ b/.github/workflows/binary_packages.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -42,7 +42,7 @@ jobs:
           openssl sha256 nanopb/dist/*.tar.gz
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: nanopb/dist/*.tar.gz
           name: nanopb-binary-linux
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
@@ -98,7 +98,7 @@ jobs:
           openssl sha256 nanopb/dist/*.zip
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: nanopb/dist/*.zip
           name: nanopb-binary-windows
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
@@ -140,7 +140,7 @@ jobs:
           openssl sha256 nanopb/dist/*.tar.gz
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: nanopb/dist/*.tar.gz
           name: nanopb-binary-macos

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,7 @@ jobs:
           dry-run: false
           sanitizer: undefined
       - name: Upload Crash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
     name: CMake on Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -42,9 +42,9 @@ jobs:
     name: CMake on Windows 2022
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,13 +45,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -78,7 +78,7 @@ jobs:
         ./.github/workflows/codeql-buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
         upload: false
@@ -107,14 +107,14 @@ jobs:
         output: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
 
     - name: Upload CodeQL results to code scanning
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ steps.step1.outputs.sarif-output }}
         category: "/language:${{matrix.language}}"
 
     - name: Upload CodeQL results as an artifact
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: codeql-results
         path: ${{ steps.step1.outputs.sarif-output }}

--- a/.github/workflows/compiler_tests.yml
+++ b/.github/workflows/compiler_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"

--- a/.github/workflows/fail_on_error.py
+++ b/.github/workflows/fail_on_error.py
@@ -11,6 +11,8 @@ def codeql_sarif_contain_error(filename):
     for run in s.get('runs', []):
         rules_metadata = run['tool']['driver']['rules']
         if not rules_metadata:
+            if 'rules' not in run['tool']['extensions'][0]:
+                return False
             rules_metadata = run['tool']['extensions'][0]['rules']
 
         for res in run.get('results', []):

--- a/.github/workflows/fil-c.yml
+++ b/.github/workflows/fil-c.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"

--- a/.github/workflows/ios_swift_tests.yml
+++ b/.github/workflows/ios_swift_tests.yml
@@ -16,7 +16,7 @@ jobs:
   swift-build-run:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Build
       run: swift build
     - name: Run

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -15,7 +15,7 @@ jobs:
     name: Meson on Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -32,9 +32,9 @@ jobs:
     name: Meson on Windows 2022
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/olddistro_tests.yml
+++ b/.github/workflows/olddistro_tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"

--- a/.github/workflows/platformio_tests.yml
+++ b/.github/workflows/platformio_tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
 

--- a/.github/workflows/simulator_tests.yml
+++ b/.github/workflows/simulator_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
@@ -41,7 +41,7 @@ jobs:
     
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"
@@ -70,7 +70,7 @@ jobs:
     
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
           fetch-depth: "0"

--- a/.github/workflows/trigger_on_code_change.yml
+++ b/.github/workflows/trigger_on_code_change.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: nanopb
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/tools/make_linux_package.sh
+++ b/tools/make_linux_package.sh
@@ -9,6 +9,9 @@ set -e
 set -x
 
 VERSION=`git describe --always`-linux-x86
+if [[ "$VERSION" != nanopb* ]]; then
+  VERSION="nanopb-0.0.0-$VERSION"
+fi
 DEST=dist/$VERSION
 
 rm -rf $DEST

--- a/tools/make_mac_package.sh
+++ b/tools/make_mac_package.sh
@@ -9,6 +9,9 @@ set -e
 set -x
 
 VERSION=`git describe --always`-macosx-x86
+if [[ "$VERSION" != nanopb* ]]; then
+  VERSION="nanopb-0.0.0-$VERSION"
+fi
 DEST=dist/$VERSION
 
 rm -rf $DEST

--- a/tools/make_windows_package.sh
+++ b/tools/make_windows_package.sh
@@ -8,6 +8,9 @@ set -e
 set -x
 
 VERSION=`git describe --always`-windows-x86
+if [[ "$VERSION" != nanopb* ]]; then
+  VERSION="nanopb-0.0.0-$VERSION"
+fi
 DEST=dist/$VERSION
 
 rm -rf $DEST


### PR DESCRIPTION
If you create a fork as github suggests and don't include all branches + tags, then CI fails miserably, see: https://github.com/check-spelling-sandbox/nanopb/actions/runs/28336774704
While it's in the process of failing, GitHub complains the the actions are using old versions of node.

- This PR fixes the main failure by defaulting to `nanopb-0.0.0` when `git describe --always` doesn't find a tag
- This PR fixes the warnings by upgrading the actions to the current versions