### PR TITLE
Encoding optimisation for small, buffer-only submessages

### DIFF
--- a/pb_encode.c
+++ b/pb_encode.c
@@ -731,6 +731,69 @@ bool checkreturn pb_encode_string(pb_ostream_t *stream, const pb_byte_t *buffer,
 }
 
 bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *fields, const void *src_struct)
+#ifdef PB_BUFFER_ONLY
+{
+    /*
+     * If we're in buffer-only mode we can skip the submessage sizing step by
+     * just reserving a byte on the stream, encoding the submessage, then
+     * writing the length in afterwards.
+     *
+     * We can't do this in stream mode as we can't go back edit the reserved
+     * byte.
+     *
+     * This only works when the submessage is <= 127 bytes (max single-byte
+     * varint), otherwise we still have to re-encode.
+     */
+    size_t bytes_written = stream->bytes_written;
+    pb_byte_t *state = (pb_byte_t*)stream->state;
+    size_t submessage_len;
+
+    /* write a placeholder byte */
+
+    if (!pb_encode_varint(stream, 0))
+        return false;
+
+    /* write the submessage */
+
+    if (!pb_encode(stream, fields, src_struct))
+        return false;
+
+    /* calculate the length, bytes_written + 1 for placeholder byte */
+
+    submessage_len = stream->bytes_written - (bytes_written + 1);
+
+    /*
+     * If less than 128 (max byte-length varint), we can just write it in the
+     * placeholder byte we reserved originally and we're done.
+     */
+
+    if (submessage_len < 128)
+    {
+        *state = (pb_byte_t)submessage_len;
+        return true;
+    }
+
+    /* otherwise, reset the stream and encode normally */
+
+    stream->bytes_written = bytes_written;
+    stream->state = state;
+
+    if (!pb_encode_varint(stream, (pb_uint64_t)submessage_len))
+        return false;
+
+    bytes_written = stream->bytes_written;
+
+    if (!pb_encode(stream, fields, src_struct))
+        return false;
+
+#if !(defined(PB_NO_ENCODE_SIZE_CHECK) && PB_NO_ENCODE_SIZE_CHECK == 1)
+    if (stream->bytes_written - bytes_written != submessage_len)
+        PB_RETURN_ERROR(stream, "submsg size changed");
+#endif
+
+  return true;
+}
+#else
 {
     /* First calculate the message size using a non-writing substream. */
     pb_ostream_t substream = PB_OSTREAM_SIZING;
@@ -784,6 +847,7 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *
     return status;
 #endif
 }
+#endif
 
 /* Field encoders */
 

--- a/tests/big_message/SConscript
+++ b/tests/big_message/SConscript
@@ -1,0 +1,16 @@
+Import("env")
+
+env.NanopbProto(["big_message", "big_message.options"])
+
+enc = env.Program(["encode_big_message.c", "big_message.pb.c", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+dec = env.Program(["decode_big_message.c", "big_message.pb.c", "$COMMON/pb_decode.o", "$COMMON/pb_common.o"])
+
+# Same output is expected, no matter if stream is written
+# out directly or through a memory buffer.
+env.RunTest('encode_big_message.output0', [enc], ARGS = ['0'])
+env.RunTest('encode_big_message.output1', [enc], ARGS = ['1'])
+env.Compare(['encode_big_message.output0', 'encode_big_message.output1'])
+
+# Similarly, decoding should work the same both ways
+env.RunTest("decode_big_message.output0", [dec, 'encode_big_message.output0'], ARGS = ['0'])
+env.RunTest("decode_big_message.output1", [dec, 'encode_big_message.output1'], ARGS = ['1'])

--- a/tests/big_message/big_message.options
+++ b/tests/big_message/big_message.options
@@ -1,0 +1,2 @@
+*.small max_size:20
+*.large max_size:20000

--- a/tests/big_message/big_message.proto
+++ b/tests/big_message/big_message.proto
@@ -1,0 +1,19 @@
+// Big (at least > 128 byte) messages with nested cases
+
+syntax = "proto2";
+
+message Three {
+    required bytes small = 1;
+    required bytes large = 2;
+}
+
+message Two {
+    required Three three = 1;
+    required bytes large = 2;
+}
+
+message One {
+    required uint32 start = 1;
+    required Two two = 2;
+    required uint32 end = 3;
+}

--- a/tests/big_message/decode_big_message.c
+++ b/tests/big_message/decode_big_message.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <pb_decode.h>
+#include <stdlib.h>
+#include "big_message.pb.h"
+#include "test_helpers.h"
+#include "unittests.h"
+
+/* This binds the pb_istream_t to stdin */
+bool callback(pb_istream_t *stream, uint8_t *buf, size_t count)
+{
+    FILE *file = (FILE*)stream->state;
+    size_t len = fread(buf, 1, count, file);
+    
+    if (len == count)
+    {
+        return true;
+    }
+    else
+    {
+        stream->bytes_left = 0;
+        return false;
+    }
+}
+
+bool check_incrementing(pb_bytes_array_t *buf, pb_size_t count)
+{
+    pb_size_t i;
+
+    if (buf->size != count) return false;
+
+    for (i = 0; i < count; i++)
+    {
+        if (buf->bytes[i] != (pb_byte_t)i) return false;
+    }
+
+    return true;
+}
+
+bool check_message(pb_istream_t *stream)
+{
+    One one = {0};
+
+    if (!pb_decode(stream, One_fields, &one))
+        return false;
+
+    int status = 0;
+
+    TEST(one.start = 42);
+    TEST(check_incrementing((pb_bytes_array_t*)&one.two.large, 20000));
+    TEST(check_incrementing((pb_bytes_array_t*)&one.two.three.large, 20000));
+    TEST(check_incrementing((pb_bytes_array_t*)&one.two.three.small, 20));
+    TEST(one.end == 43);
+
+    return status == 0;
+}
+
+int main(int argc, const char **argv)
+{
+    int mode = 0;
+    pb_istream_t stream;
+    pb_byte_t buffer[One_size];
+#ifndef PB_BUFFER_ONLY
+    stream = (pb_istream_t){&callback, NULL, SIZE_MAX}
+#endif
+
+    SET_BINARY_MODE(stdin);
+    stream.state = stdin;
+
+    /* In mode 0, buffer is used.
+     * In other modes, direct stdin stream is used
+     */
+    if (argc > 1) mode = atoi(argv[1]);
+
+    if (mode == 0)
+    {
+        size_t count = fread(buffer, 1, sizeof(buffer), stdin);
+        stream = pb_istream_from_buffer(buffer, count);
+    }
+
+    if (!check_message(&stream))
+    {
+        fprintf(stderr, "Test failed: %s\n", PB_GET_ERROR(&stream));
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/tests/big_message/encode_big_message.c
+++ b/tests/big_message/encode_big_message.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pb_encode.h>
+#include "test_helpers.h"
+#include "big_message.pb.h"
+
+/* This binds the pb_ostream_t into the stdout stream */
+bool streamcallback(pb_ostream_t *stream, const uint8_t *buf, size_t count)
+{
+    FILE *file = (FILE*) stream->state;
+    return fwrite(buf, 1, count, file) == count;
+}
+
+void write_incrementing(pb_bytes_array_t* buf, pb_size_t count)
+{
+    pb_size_t i;
+    for (i = 0; i < count; i++)
+        buf->bytes[i] = (pb_byte_t)i;
+    buf->size = count;
+}
+
+int main(int argc, const char **argv)
+{
+    int mode = 0;
+    pb_byte_t buffer[One_size];
+    pb_ostream_t stream;
+#ifndef PB_BUFFER_ONLY
+    stream = (pb_ostream_t){&streamcallback, NULL, One_size, 0}
+#endif
+
+    SET_BINARY_MODE(stdout);
+    stream.state = stdout;
+
+    /*
+     * In mode 0, buffer is used.
+     * In other modes, direct stdout stream is used
+     */
+    if (argc > 1) mode = atoi(argv[1]);
+
+    if (mode == 0)
+    {
+        stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+    }
+
+    One one = One_init_default;
+    one.start = 42;
+    write_incrementing((pb_bytes_array_t*)&one.two.large, 20000);
+    write_incrementing((pb_bytes_array_t*)&one.two.three.large, 20000);
+    write_incrementing((pb_bytes_array_t*)&one.two.three.small, 20);
+    one.end = 43;
+
+    if (pb_encode(&stream, One_fields, &one))
+    {
+        if (mode == 0)
+        {
+            fwrite(buffer, stream.bytes_written, 1, stdout);
+        }
+
+        return 0;
+    }
+    else
+    {
+        fprintf(stderr, "Encoding failed: %s\n", PB_GET_ERROR(&stream));
+        return 1;
+    }
+}

--- a/tests/buffer_only/SConscript
+++ b/tests/buffer_only/SConscript
@@ -8,6 +8,10 @@ env.Command("alltypes.pb.h", "$BUILD/alltypes/alltypes.pb.h", c)
 env.Command("alltypes.pb.c", "$BUILD/alltypes/alltypes.pb.c", c)
 env.Command("encode_alltypes.c", "$BUILD/alltypes/encode_alltypes.c", c)
 env.Command("decode_alltypes.c", "$BUILD/alltypes/decode_alltypes.c", c)
+env.Command("big_message.pb.h", "$BUILD/big_message/big_message.pb.h", c)
+env.Command("big_message.pb.c", "$BUILD/big_message/big_message.pb.c", c)
+env.Command("decode_big_message.c", "$BUILD/big_message/decode_big_message.c", c)
+env.Command("encode_big_message.c", "$BUILD/big_message/encode_big_message.c", c)
 
 # Define the compilation options
 opts = env.Clone()
@@ -24,5 +28,11 @@ strict.Object("pb_common_bufonly.o", "$NANOPB/pb_common.c")
 enc = opts.Program(["encode_alltypes.c", "alltypes.pb.c", "pb_encode_bufonly.o", "pb_common_bufonly.o"])
 dec = opts.Program(["decode_alltypes.c", "alltypes.pb.c", "pb_decode_bufonly.o", "pb_common_bufonly.o"])
 
+big_enc = opts.Program(["encode_big_message.c", "big_message.pb.c", "pb_encode_bufonly.o", "pb_common_bufonly.o"])
+big_dec = opts.Program(["decode_big_message.c", "big_message.pb.c", "pb_decode_bufonly.o", "pb_common_bufonly.o"])
+
 env.RunTest(enc)
 env.RunTest([dec, "encode_alltypes.output"])
+
+env.RunTest(big_enc)
+env.RunTest([big_dec, "encode_big_message.output"])

--- a/tests/timing/SConscript
+++ b/tests/timing/SConscript
@@ -1,0 +1,24 @@
+Import("env")
+
+c = Copy("$TARGET", "$SOURCE")
+env.Command("timing_bufonly.c", "timing.c", c)
+env.Command("deep.pb.h", "$BUILD/deep_structure/deep.pb.h", c)
+env.Command("deep.pb.c", "$BUILD/deep_structure/deep.pb.c", c)
+
+opts = env.Clone()
+opts.Append(CPPDEFINES = {'PB_BUFFER_ONLY': 1})
+
+# Build new version of core
+strict = opts.Clone()
+strict.Append(CFLAGS = strict['CORECFLAGS'])
+strict.Object("pb_decode_bufonly.o", "$NANOPB/pb_decode.c")
+strict.Object("pb_encode_bufonly.o", "$NANOPB/pb_encode.c")
+strict.Object("pb_common_bufonly.o", "$NANOPB/pb_common.c")
+
+
+# Now build and run the test normally.
+bufonly = opts.Program(["timing_bufonly.c", "deep.pb.c", "pb_encode_bufonly.o", "pb_common_bufonly.o"])
+normal = opts.Program(["timing.c", "deep.pb.c", "$COMMON/pb_encode.o", "$COMMON/pb_common.o"])
+
+env.RunTest(bufonly)
+env.RunTest(normal)

--- a/tests/timing/timing.c
+++ b/tests/timing/timing.c
@@ -1,0 +1,50 @@
+#define _POSIX_C_SOURCE 199309L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pb_encode.h>
+#include "test_helpers.h"
+#include "deep.pb.h"
+#include <time.h>
+
+long get_ms(void);
+
+long get_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+}
+
+
+int main(void)
+{
+    pb_byte_t buffer[DeepMessage_size];
+    pb_ostream_t stream;
+
+    int i;
+    long start;
+    long duration = 0;
+
+    DeepMessage msg = {0};
+
+    strcpy(msg.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.strval, "abcd");
+    msg.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.m.intval = 987654321;
+    msg.first = 888;
+    msg.last = 999;
+
+    stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+    start = get_ms();
+    for (i = 0; i < 10000; i++)
+    {
+        stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+        if (!pb_encode(&stream, DeepMessage_fields, &msg))
+            return 1;
+        
+    }
+    duration = get_ms() - start;
+    fprintf(stderr, "took %ld ms\n", duration);
+    return 0;
+}


### PR DESCRIPTION
## Overview

If a submessage is < 128 bytes, we can skip the sizing step by reserving a byte for length and writing it in after the submessage has been encoded.

If it turns out to be larger, we can reset the stream and encode as we usually would.

In the ideal case, this drops the number of `pb_encode_submessage()` calls for an $n$-nested message from $n^2$ to $n$.

You get no where near the speedup you would vs manually encoding a message but it's probably worth getting in as messages are very frequently (like most in the test suite) < 128 bytes.

Haven't searched too much so apologies if this has been considered before and rejected!

## Testing

Added a temporary (prints time to encode to `stderr`) timing test to demonstrate the difference. I used the `.proto` files from the `deep_structure` test to demonstrate an extremely bad case + improvement (~9x speedup).

Also added a test with a submessage >= 128 bytes as I couldn't find one and also added this to the buffer-only tests.

Sorry for any abuse of the test framework, I'm not an expert!