### PR TITLE
Improve diagnostics for invalid options patterns

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2390,6 +2390,24 @@ class ProtoFile:
 
 from fnmatch import fnmatchcase
 
+def validate_options_namemask(namemask, filename, line_number):
+    '''Verify that an options pattern contains only protobuf path and fnmatch characters.'''
+    # File options match .proto paths, which can contain punctuation that is
+    # not valid in field names.
+    if '/' in namemask or namemask.endswith('.proto'):
+        invalid = re.search(r'[\s:]', namemask)
+    else:
+        invalid = re.search(r'[^A-Za-z0-9_.*?\[\]!]', namemask)
+    if invalid:
+        hint = ""
+        if invalid.group(0) == ':':
+            hint = " Did you mean to separate the field pattern from options with whitespace?"
+
+        sys.stderr.write("%s:%d: " % (filename, line_number) +
+                         "Invalid character %r in option field pattern %r.%s\n" %
+                         (invalid.group(0), namemask, hint))
+        sys.exit(1)
+
 def read_options_file(infile):
     '''Parse a separate options file to list:
         [(namemask, options), ...]
@@ -2411,6 +2429,8 @@ def read_options_file(infile):
                              "Option lines should have space between field name and options. " +
                              "Skipping line: '%s'\n" % line)
             sys.exit(1)
+
+        validate_options_namemask(parts[0], infile.name, i + 1)
 
         opts = nanopb_pb2.NanoPBOptions()
 

--- a/tests/regression/issue_954/SConscript
+++ b/tests/regression/issue_954/SConscript
@@ -1,0 +1,6 @@
+# Regression test for issue #954:
+# Give a clear diagnostic for stray punctuation in .options field patterns.
+
+Import("env")
+
+env.Command("test_options_diagnostics.output", "test_options_diagnostics.py", "$PYTHON $SOURCE > $TARGET")

--- a/tests/regression/issue_954/test_options_diagnostics.py
+++ b/tests/regression/issue_954/test_options_diagnostics.py
@@ -1,0 +1,51 @@
+import io
+import sys
+from pathlib import Path
+from contextlib import redirect_stderr
+
+def find_repo_root():
+    for start in (Path(__file__).resolve(), Path.cwd().resolve()):
+        for path in (start,) + tuple(start.parents):
+            if (path / "generator" / "nanopb_generator.py").is_file():
+                return path
+    raise RuntimeError("could not find nanopb repository root")
+
+
+sys.path.insert(0, str(find_repo_root()))
+
+from generator import nanopb_generator
+
+
+class NamedStringIO(io.StringIO):
+    name = "invalid.options"
+
+
+def expect_invalid_pattern():
+    options_file = NamedStringIO("edv.GatewayMessage: type: FT_POINTER\n")
+    stderr = io.StringIO()
+
+    try:
+        with redirect_stderr(stderr):
+            nanopb_generator.read_options_file(options_file)
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("invalid options pattern was accepted")
+
+    message = stderr.getvalue()
+    assert "invalid.options:1" in message
+    assert "Invalid character ':'" in message
+    assert "separate the field pattern from options with whitespace" in message
+
+
+def expect_file_pattern():
+    options_file = NamedStringIO("dir/file-name.proto package:\"demo\"\n")
+    result = nanopb_generator.read_options_file(options_file)
+
+    assert result[0][0] == "dir/file-name.proto"
+
+
+if __name__ == "__main__":
+    expect_invalid_pattern()
+    expect_file_pattern()
+    sys.stdout.write("ok\n")


### PR DESCRIPTION
﻿## Summary
- validate .options field patterns as soon as they are read
- report the invalid character and a whitespace hint for stray ':' separators
- add a regression test for issue #954, including a valid .proto file pattern

## Tests
- python -m py_compile generator\nanopb_generator.py tests\regression\issue_954\test_options_diagnostics.py
- direct tests\regression\issue_954\test_options_diagnostics.py run in a temporary Python 3.12 venv with generated nanopb_pb2.py
- SCons single target for regression/issue_954 run in the same temporary venv
- git diff --check

Fixes #954
