### PR TITLE
cmake: require 3.5 for legacy examples

### DIFF
--- a/build-tests/cmake_with_components/CMakeLists.txt
+++ b/build-tests/cmake_with_components/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(NANOPB_CMAKE_SIMPLE C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)

--- a/build-tests/legacy_cmake_relpath/CMakeLists.txt
+++ b/build-tests/legacy_cmake_relpath/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(NANOPB_CMAKE_SIMPLE C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)

--- a/build-tests/legacy_cmake_simple/CMakeLists.txt
+++ b/build-tests/legacy_cmake_simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(NANOPB_CMAKE_SIMPLE C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)

--- a/conan-wrapper/CMakeLists.txt
+++ b/conan-wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cmake_wrapper)
 
 include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)

--- a/examples/cmake_relpath/CMakeLists.txt
+++ b/examples/cmake_relpath/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(NANOPB_CMAKE_SIMPLE C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)

--- a/examples/cmake_simple/CMakeLists.txt
+++ b/examples/cmake_simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(NANOPB_CMAKE_SIMPLE C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../extra)


### PR DESCRIPTION
﻿## Summary
- raise the remaining example and build-test `cmake_minimum_required` declarations from 2.8/2.8.12 to 3.5
- keep the existing CMake logic unchanged while avoiding CMake 4's removal of compatibility with versions older than 3.5

Fixes #1128

## Testing
- `git diff --check HEAD~1..HEAD`
- scanned CMake files for remaining minimum versions below 3.5
- `git ls-files --eol` for the changed CMakeLists files
- Not run: CMake configure/build, because `cmake` is not installed on this Windows host.
