### PR TITLE
Fix comment parsing in options string literals

### DIFF
--- a/generator/nanopb_generator.py
+++ b/generator/nanopb_generator.py
@@ -2408,15 +2408,27 @@ def validate_options_namemask(namemask, filename, line_number):
                          (invalid.group(0), namemask, hint))
         sys.exit(1)
 
+def strip_options_comments(data):
+    '''Remove comments from .options data without touching quoted strings.'''
+    string_or_comment = re.compile(
+        r'''(?P<string>"(?:\\.|[^"\\\r\n])*(?:"|$)|'(?:\\.|[^'\\\r\n])*(?:'|$))'''
+        r'''|(?P<comment>/\*.*?(?:\*/|\Z)|//[^\r\n]*|#[^\r\n]*)''',
+        flags = re.MULTILINE | re.DOTALL)
+
+    def strip_comment(match):
+        if match.group('string'):
+            return match.group('string')
+
+        return re.sub(r'[^\r\n]', '', match.group('comment'))
+
+    return string_or_comment.sub(strip_comment, data)
+
 def read_options_file(infile):
     '''Parse a separate options file to list:
         [(namemask, options), ...]
     '''
     results = []
-    data = infile.read()
-    data = re.sub(r'/\*.*?\*/', '', data, flags = re.MULTILINE)
-    data = re.sub(r'//.*?$', '', data, flags = re.MULTILINE)
-    data = re.sub(r'#.*?$', '', data, flags = re.MULTILINE)
+    data = strip_options_comments(infile.read())
     for i, line in enumerate(data.split('\n')):
         line = line.strip()
         if not line:

--- a/tests/regression/issue_954/SConscript
+++ b/tests/regression/issue_954/SConscript
@@ -3,4 +3,8 @@
 
 Import("env")
 
+import sys
+
+env = env.Clone()
+env["PYTHON"] = env["ESCAPE"](sys.executable)
 env.Command("test_options_diagnostics.output", "test_options_diagnostics.py", "$PYTHON $SOURCE > $TARGET")

--- a/tests/regression/issue_954/test_options_diagnostics.py
+++ b/tests/regression/issue_954/test_options_diagnostics.py
@@ -45,7 +45,21 @@ def expect_file_pattern():
     assert result[0][0] == "dir/file-name.proto"
 
 
+def expect_comment_markers_in_strings():
+    options_file = NamedStringIO(
+        "Message.url callback_datatype:\"http://example.com\" // trailing comment\n"
+        "Message.tag callback_datatype:\"value#tag\" # trailing comment\n"
+        "Message.block callback_datatype:\"value/*tag*/\" /* trailing comment */\n"
+    )
+    result = nanopb_generator.read_options_file(options_file)
+
+    assert result[0][1].callback_datatype == "http://example.com"
+    assert result[1][1].callback_datatype == "value#tag"
+    assert result[2][1].callback_datatype == "value/*tag*/"
+
+
 if __name__ == "__main__":
     expect_invalid_pattern()
     expect_file_pattern()
+    expect_comment_markers_in_strings()
     sys.stdout.write("ok\n")


### PR DESCRIPTION
## Summary
- replace the order-dependent comment regex passes with one string-aware regex
- preserve //, #, and /* */ markers when they are part of quoted option values
- keep line numbers stable when removing multiline block comments
- extend the existing options diagnostics regression to cover all three comment markers in strings
- run the diagnostics regression with the active SCons Python interpreter so binary package tests use the environment that has protobuf installed

## Duplicate check
- No open PR found for `read_options_file`, `options comment string callback_datatype`, or `callback_datatype`.
- Open issue search for `callback_datatype` only found #1031, which is unrelated to comment parsing.

## Tests
- `./.venv/Scripts/python.exe tests/regression/issue_954/test_options_diagnostics.py`
- From `tests`: `../.venv/Scripts/python.exe -m SCons build/regression/issue_954/test_options_diagnostics.output`
- From `tests`, with `.venv/Scripts` prepended to `PATH`: `../.venv/Scripts/python.exe -m SCons build/regression/issue_145/comments.pb.h`
- 51-case differential check against the previous scanner: 45 repository `.options` files plus quoted markers, escapes, multiline comments, and unterminated input; 0 mismatches
- `./.venv/Scripts/python.exe -m py_compile generator/nanopb_generator.py tests/regression/issue_954/test_options_diagnostics.py`
- `git diff --check`
- `git ls-files --eol generator/nanopb_generator.py tests/regression/issue_954/test_options_diagnostics.py tests/regression/issue_954/SConscript`