### PR TITLE
Fix missing _proto directory in Windows package

### DIFF
--- a/tools/make_windows_package.sh
+++ b/tools/make_windows_package.sh
@@ -29,6 +29,7 @@ mv $DEST/generator/dist/nanopb_generator $DEST/generator-bin
 cp $DEST/generator/dist/protoc/protoc.exe $DEST/generator-bin
 
 # Include Google's descriptor.proto and nanopb.proto
+mkdir -p $DEST/generator-bin/grpc_tools/
 cp -pr $(python3 -c 'import grpc_tools, os.path; print(os.path.dirname(grpc_tools.__file__))')/_proto $DEST/generator-bin/grpc_tools/
 cp -pr $DEST/generator/proto $DEST/generator-bin/proto
 


### PR DESCRIPTION
Fixes #1182.

Create `generator-bin/grpc_tools` before copying `_proto`, so `cp` keeps the `_proto` directory in the Windows package instead of copying only its contents.

Tested with the binary package workflow: https://github.com/Huoyanlifusu/nanopb/actions/runs/33457513112. All three jobs passed, including Windows 2022.